### PR TITLE
fix panic for corner case (thanks to fuzz-go)

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -578,7 +578,7 @@ func (p *Parser) ChallengeHTTPLibrary(agent string, result *Result) error {
 
 		agentLen := len(agent)
 		if agentLen > i+10 { // Longer than "...HttpClient"
-			if agent[i+11] == '/' {
+			if agentLen > i+11 && agent[i+11] == '/' {
 				goto MATCH_JAVA_MISC
 			}
 			return ErrNoMatch


### PR DESCRIPTION
example code:
```
package main

import (
	"log"

	"github.com/woothee/woothee-go"
)

func main() {
	agent := `-HttpClient0`
	result, err := woothee.Parse(agent)    // panic!!
	if err != nil {
		log.Fatalf("Could not parse '%s': %s", agent, err)
	}

	log.Println(result)
}
```

I get the following error:
```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/woothee/woothee-go.(*Parser).ChallengeHTTPLibrary(0xc42000c168, 0x10fc591, 0xc, 0xc4200b5ab0, 0x1167280, 0xc42000f500)
	/Users/hattori-h/.golang/src/github.com/woothee/woothee-go/parser.go:571 +0x202
github.com/woothee/woothee-go.(*Parser).TryRareCases(0xc42000c168, 0x10fc591, 0xc, 0xc4200b5ab0, 0x1167280, 0xc42000f500)
	/Users/hattori-h/.golang/src/github.com/woothee/woothee-go/parser.go:314 +0xcb
github.com/woothee/woothee-go.(*Parser).Parse(0xc42000c168, 0x10fc591, 0xc, 0x10e2620, 0xc420080401, 0xc42000c168)
	/Users/hattori-h/.golang/src/github.com/woothee/woothee-go/parser.go:94 +0x31d
github.com/woothee/woothee-go.Parse(0x10fc591, 0xc, 0x0, 0xc42003ff68, 0x10c2e13)
	/Users/hattori-h/.golang/src/github.com/woothee/woothee-go/woothee.go:53 +0x41
main.main()
	/Users/hattori-h/p.go:11 +0x48
exit status 2
```

This bug could be found with using [go-fuzz](https://github.com/dvyukov/go-fuzz) .

Thanks.