### PR TITLE
Support v1.10 spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# spec project fetched to update _test.go
+woothee/

--- a/appliance_test.go
+++ b/appliance_test.go
@@ -18,13 +18,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "Nintendo 3DS" {
 			t.Errorf("Expected result.Name for '%s' to be 'Nintendo 3DS', but got '%s'", `Mozilla/5.0 (Nintendo 3DS; U; ; ja) Version/1.7455.JP`, result.Name)
 		}
-		if result.Os != "Nintendo 3DS" {
+		if true && result.Os != "Nintendo 3DS" {
 			t.Errorf("Expected result.Os for '%s' to be 'Nintendo 3DS', but got '%s'", `Mozilla/5.0 (Nintendo 3DS; U; ; ja) Version/1.7455.JP`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Nintendo 3DS; U; ; ja) Version/1.7455.JP`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Nintendo 3DS; U; ; ja) Version/1.7455.JP`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Opera/9.50 (Nintendo DSi; Opera/507; U; ja)`, result.Name)
 		}
-		if result.Os != "Nintendo DSi" {
+		if true && result.Os != "Nintendo DSi" {
 			t.Errorf("Expected result.Os for '%s' to be 'Nintendo DSi', but got '%s'", `Opera/9.50 (Nintendo DSi; Opera/507; U; ja)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Opera/9.50 (Nintendo DSi; Opera/507; U; ja)`, result.OsVersion)
 		}
-		if result.Version != "9.50" {
+		if true && result.Version != "9.50" {
 			t.Errorf("Expected result.Version for '%s' to be '9.50', but got '%s'", `Opera/9.50 (Nintendo DSi; Opera/507; U; ja)`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Opera/9.30 (Nintendo Wii; U; ; 3642; ja)`, result.Name)
 		}
-		if result.Os != "Nintendo Wii" {
+		if true && result.Os != "Nintendo Wii" {
 			t.Errorf("Expected result.Os for '%s' to be 'Nintendo Wii', but got '%s'", `Opera/9.30 (Nintendo Wii; U; ; 3642; ja)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Opera/9.30 (Nintendo Wii; U; ; 3642; ja)`, result.OsVersion)
 		}
-		if result.Version != "9.30" {
+		if true && result.Version != "9.30" {
 			t.Errorf("Expected result.Version for '%s' to be '9.30', but got '%s'", `Opera/9.30 (Nintendo Wii; U; ; 3642; ja)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "Nintendo Wii U" {
 			t.Errorf("Expected result.Name for '%s' to be 'Nintendo Wii U', but got '%s'", `Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US`, result.Name)
 		}
-		if result.Os != "Nintendo Wii U" {
+		if true && result.Os != "Nintendo Wii U" {
 			t.Errorf("Expected result.Os for '%s' to be 'Nintendo Wii U', but got '%s'", `Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "PlayStation 3" {
 			t.Errorf("Expected result.Name for '%s' to be 'PlayStation 3', but got '%s'", `Mozilla/5.0 (PLAYSTATION 3; 1.00)`, result.Name)
 		}
-		if result.Os != "PlayStation 3" {
+		if true && result.Os != "PlayStation 3" {
 			t.Errorf("Expected result.Os for '%s' to be 'PlayStation 3', but got '%s'", `Mozilla/5.0 (PLAYSTATION 3; 1.00)`, result.Os)
 		}
-		if result.OsVersion != "1.00" {
+		if true && result.OsVersion != "1.00" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '1.00', but got '%s'", `Mozilla/5.0 (PLAYSTATION 3; 1.00)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (PLAYSTATION 3; 1.00)`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "PlayStation 3" {
 			t.Errorf("Expected result.Name for '%s' to be 'PlayStation 3', but got '%s'", `Mozilla/5.0 (PLAYSTATION 3 4.31) AppleWebKit/531.22.8 (KHTML, like Gecko)`, result.Name)
 		}
-		if result.Os != "PlayStation 3" {
+		if true && result.Os != "PlayStation 3" {
 			t.Errorf("Expected result.Os for '%s' to be 'PlayStation 3', but got '%s'", `Mozilla/5.0 (PLAYSTATION 3 4.31) AppleWebKit/531.22.8 (KHTML, like Gecko)`, result.Os)
 		}
-		if result.OsVersion != "4.31" {
+		if true && result.OsVersion != "4.31" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '4.31', but got '%s'", `Mozilla/5.0 (PLAYSTATION 3 4.31) AppleWebKit/531.22.8 (KHTML, like Gecko)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (PLAYSTATION 3 4.31) AppleWebKit/531.22.8 (KHTML, like Gecko)`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "PlayStation 4" {
 			t.Errorf("Expected result.Name for '%s' to be 'PlayStation 4', but got '%s'", `Mozilla/5.0 (PlayStation 4 1.000) AppleWebKit/536.26 (KHTML, like Gecko)`, result.Name)
 		}
-		if result.Os != "PlayStation 4" {
+		if true && result.Os != "PlayStation 4" {
 			t.Errorf("Expected result.Os for '%s' to be 'PlayStation 4', but got '%s'", `Mozilla/5.0 (PlayStation 4 1.000) AppleWebKit/536.26 (KHTML, like Gecko)`, result.Os)
 		}
-		if result.OsVersion != "1.000" {
+		if true && result.OsVersion != "1.000" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '1.000', but got '%s'", `Mozilla/5.0 (PlayStation 4 1.000) AppleWebKit/536.26 (KHTML, like Gecko)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (PlayStation 4 1.000) AppleWebKit/536.26 (KHTML, like Gecko)`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "PlayStation Portable" {
 			t.Errorf("Expected result.Name for '%s' to be 'PlayStation Portable', but got '%s'", `Mozilla/4.0 (PSP (PlayStation Portable); 2.00)`, result.Name)
 		}
-		if result.Os != "PlayStation Portable" {
+		if true && result.Os != "PlayStation Portable" {
 			t.Errorf("Expected result.Os for '%s' to be 'PlayStation Portable', but got '%s'", `Mozilla/4.0 (PSP (PlayStation Portable); 2.00)`, result.Os)
 		}
-		if result.OsVersion != "2.00" {
+		if true && result.OsVersion != "2.00" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '2.00', but got '%s'", `Mozilla/4.0 (PSP (PlayStation Portable); 2.00)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.0 (PSP (PlayStation Portable); 2.00)`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "PlayStation Vita" {
 			t.Errorf("Expected result.Name for '%s' to be 'PlayStation Vita', but got '%s'", `Mozilla/5.0 (PlayStation Vita 1.51) AppleWebKit/531.22.8 (KHTML, like Gecko) Silk/3.2`, result.Name)
 		}
-		if result.Os != "PlayStation Vita" {
+		if true && result.Os != "PlayStation Vita" {
 			t.Errorf("Expected result.Os for '%s' to be 'PlayStation Vita', but got '%s'", `Mozilla/5.0 (PlayStation Vita 1.51) AppleWebKit/531.22.8 (KHTML, like Gecko) Silk/3.2`, result.Os)
 		}
-		if result.OsVersion != "1.51" {
+		if true && result.OsVersion != "1.51" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '1.51', but got '%s'", `Mozilla/5.0 (PlayStation Vita 1.51) AppleWebKit/531.22.8 (KHTML, like Gecko) Silk/3.2`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (PlayStation Vita 1.51) AppleWebKit/531.22.8 (KHTML, like Gecko) Silk/3.2`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "Xbox 360" {
 			t.Errorf("Expected result.Name for '%s' to be 'Xbox 360', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)`, result.Name)
 		}
-		if result.Os != "Xbox 360" {
+		if true && result.Os != "Xbox 360" {
 			t.Errorf("Expected result.Os for '%s' to be 'Xbox 360', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)`, result.Version)
 		}
 	}
@@ -218,13 +218,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "Xbox One" {
 			t.Errorf("Expected result.Name for '%s' to be 'Xbox One', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)`, result.Name)
 		}
-		if result.Os != "Xbox One" {
+		if true && result.Os != "Xbox One" {
 			t.Errorf("Expected result.Os for '%s' to be 'Xbox One', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)`, result.Version)
 		}
 	}
@@ -238,13 +238,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "InternetTVBrowser" {
 			t.Errorf("Expected result.Name for '%s' to be 'InternetTVBrowser', but got '%s'", `Mozilla/5.0 (DTV; TSBNetTV/TXXXXXXXXX.0203.ADD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) InettvBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) YahooDTV/1.1 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)`, result.Name)
 		}
-		if result.Os != "DigitalTV" {
+		if true && result.Os != "DigitalTV" {
 			t.Errorf("Expected result.Os for '%s' to be 'DigitalTV', but got '%s'", `Mozilla/5.0 (DTV; TSBNetTV/TXXXXXXXXX.0203.ADD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) InettvBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) YahooDTV/1.1 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (DTV; TSBNetTV/TXXXXXXXXX.0203.ADD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) InettvBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) YahooDTV/1.1 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (DTV; TSBNetTV/TXXXXXXXXX.0203.ADD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) InettvBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) YahooDTV/1.1 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)`, result.Version)
 		}
 	}
@@ -258,13 +258,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "InternetTVBrowser" {
 			t.Errorf("Expected result.Name for '%s' to be 'InternetTVBrowser', but got '%s'", `Mozilla/5.0 (DTV; TVwithVideoPlayer) NetFront/4.1 InettvBrowser/2.2 (08001F;DTV04VSFC3;0001;0001)`, result.Name)
 		}
-		if result.Os != "DigitalTV" {
+		if true && result.Os != "DigitalTV" {
 			t.Errorf("Expected result.Os for '%s' to be 'DigitalTV', but got '%s'", `Mozilla/5.0 (DTV; TVwithVideoPlayer) NetFront/4.1 InettvBrowser/2.2 (08001F;DTV04VSFC3;0001;0001)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (DTV; TVwithVideoPlayer) NetFront/4.1 InettvBrowser/2.2 (08001F;DTV04VSFC3;0001;0001)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (DTV; TVwithVideoPlayer) NetFront/4.1 InettvBrowser/2.2 (08001F;DTV04VSFC3;0001;0001)`, result.Version)
 		}
 	}
@@ -278,13 +278,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "InternetTVBrowser" {
 			t.Errorf("Expected result.Name for '%s' to be 'InternetTVBrowser', but got '%s'", `Mozilla/5.0 (DTV; TSBNetTV/T45000006.0203.CDD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;T45011C06;0203;CDD) InettvBrowser/2.2 (000039;T45011C06;0203;CDD)`, result.Name)
 		}
-		if result.Os != "DigitalTV" {
+		if true && result.Os != "DigitalTV" {
 			t.Errorf("Expected result.Os for '%s' to be 'DigitalTV', but got '%s'", `Mozilla/5.0 (DTV; TSBNetTV/T45000006.0203.CDD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;T45011C06;0203;CDD) InettvBrowser/2.2 (000039;T45011C06;0203;CDD)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (DTV; TSBNetTV/T45000006.0203.CDD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;T45011C06;0203;CDD) InettvBrowser/2.2 (000039;T45011C06;0203;CDD)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (DTV; TSBNetTV/T45000006.0203.CDD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;T45011C06;0203;CDD) InettvBrowser/2.2 (000039;T45011C06;0203;CDD)`, result.Version)
 		}
 	}
@@ -298,13 +298,13 @@ func Test_appliance(t *testing.T) {
 		if result.Name != "InternetTVBrowser" {
 			t.Errorf("Expected result.Name for '%s' to be 'InternetTVBrowser', but got '%s'", `Mozilla/5.0 (Standard; NF34SW/1.1; like Gecko) NetFront/3.4 InettvBrowser/2.2C (000087;IP03-01;0100;0000)`, result.Name)
 		}
-		if result.Os != "DigitalTV" {
+		if true && result.Os != "DigitalTV" {
 			t.Errorf("Expected result.Os for '%s' to be 'DigitalTV', but got '%s'", `Mozilla/5.0 (Standard; NF34SW/1.1; like Gecko) NetFront/3.4 InettvBrowser/2.2C (000087;IP03-01;0100;0000)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Standard; NF34SW/1.1; like Gecko) NetFront/3.4 InettvBrowser/2.2C (000087;IP03-01;0100;0000)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Standard; NF34SW/1.1; like Gecko) NetFront/3.4 InettvBrowser/2.2C (000087;IP03-01;0100;0000)`, result.Version)
 		}
 	}

--- a/appliance_test.go
+++ b/appliance_test.go
@@ -204,12 +204,9 @@ func Test_appliance(t *testing.T) {
 		if result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)`, result.OsVersion)
 		}
-
-		/* XXX SKIP for now
 		if result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)`, result.Version)
 		}
-		*/
 	}
 	result, err = Parse(`Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)`)
 	if err != nil {
@@ -227,11 +224,9 @@ func Test_appliance(t *testing.T) {
 		if result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)`, result.OsVersion)
 		}
-		/* Skip for now
 		if result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)`, result.Version)
 		}
-		*/
 	}
 	result, err = Parse(`Mozilla/5.0 (DTV; TSBNetTV/TXXXXXXXXX.0203.ADD; like Gecko) NetFront/3.4 DTVNetBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) InettvBrowser/2.2 (000039;TXXXXXXXXX;0203;ADD) YahooDTV/1.1 (Video=0x03;Audio=0x01;Screen=0x01;Device=0x00;Remote=0x10)`)
 	if err != nil {

--- a/blank_test.go
+++ b/blank_test.go
@@ -48,44 +48,24 @@ func Test_blank(t *testing.T) {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Version)
 		}
 	}
-	result, err = Parse(``)
+	result, err = Parse(`-`)
 	if err != nil {
-		t.Errorf(`Failed to parse '': %s`, err)
+		t.Errorf(`Failed to parse '-': %s`, err)
 	} else {
 		if result.Category != "UNKNOWN" {
-			t.Errorf("Expected result.Category for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Category)
+			t.Errorf("Expected result.Category for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.Category)
 		}
 		if result.Name != "UNKNOWN" {
-			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Name)
+			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.Name)
 		}
 		if result.Os != "UNKNOWN" {
-			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Os)
+			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.Os)
 		}
 		if result.OsVersion != "UNKNOWN" {
-			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", ``, result.OsVersion)
+			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.OsVersion)
 		}
 		if result.Version != "UNKNOWN" {
-			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Version)
-		}
-	}
-	result, err = Parse(``)
-	if err != nil {
-		t.Errorf(`Failed to parse '': %s`, err)
-	} else {
-		if result.Category != "UNKNOWN" {
-			t.Errorf("Expected result.Category for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Category)
-		}
-		if result.Name != "UNKNOWN" {
-			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Name)
-		}
-		if result.Os != "UNKNOWN" {
-			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Os)
-		}
-		if result.OsVersion != "UNKNOWN" {
-			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", ``, result.OsVersion)
-		}
-		if result.Version != "UNKNOWN" {
-			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Version)
+			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.Version)
 		}
 	}
 

--- a/blank_test.go
+++ b/blank_test.go
@@ -18,13 +18,13 @@ func Test_blank(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if true && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", ``, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if true && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_blank(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if true && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", ``, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if true && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", ``, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_blank(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if true && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if true && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `-`, result.Version)
 		}
 	}

--- a/crawler_google_test.go
+++ b/crawler_google_test.go
@@ -18,13 +18,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Googlebot" {
 			t.Errorf("Expected result.Name for '%s' to be 'Googlebot', but got '%s'", `Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Googlebot" {
 			t.Errorf("Expected result.Name for '%s' to be 'Googlebot', but got '%s'", `Googlebot-Image/1.0`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Googlebot-Image/1.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Googlebot-Image/1.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Googlebot-Image/1.0`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Googlebot Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'Googlebot Mobile', but got '%s'", `DoCoMo/2.0 N905i(c100;TB;W24H16) (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 N905i(c100;TB;W24H16) (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 N905i(c100;TB;W24H16) (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 N905i(c100;TB;W24H16) (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Googlebot Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'Googlebot Mobile', but got '%s'", `SAMSUNG-SGH-E250/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `SAMSUNG-SGH-E250/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `SAMSUNG-SGH-E250/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `SAMSUNG-SGH-E250/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/6.2.3.3.c.1.101 (GUI) MMP/2.0 (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Google Mediapartners" {
 			t.Errorf("Expected result.Name for '%s' to be 'Google Mediapartners', but got '%s'", `DoCoMo/2.0 SH905i(c100;TB;W24H16) (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 SH905i(c100;TB;W24H16) (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 SH905i(c100;TB;W24H16) (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 SH905i(c100;TB;W24H16) (compatible; Mediapartners-Google/2.1; +http://www.google.com/bot.html)`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Google Mediapartners" {
 			t.Errorf("Expected result.Name for '%s' to be 'Google Mediapartners', but got '%s'", `Mediapartners-Google`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mediapartners-Google`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mediapartners-Google`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mediapartners-Google`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Google Feedfetcher" {
 			t.Errorf("Expected result.Name for '%s' to be 'Google Feedfetcher', but got '%s'", `Feedfetcher-Google; (+http://www.google.com/feedfetcher.html; feed-id=000000000000000000)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Feedfetcher-Google; (+http://www.google.com/feedfetcher.html; feed-id=000000000000000000)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Feedfetcher-Google; (+http://www.google.com/feedfetcher.html; feed-id=000000000000000000)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Feedfetcher-Google; (+http://www.google.com/feedfetcher.html; feed-id=000000000000000000)`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Google AppEngine" {
 			t.Errorf("Expected result.Name for '%s' to be 'Google AppEngine', but got '%s'", `AppEngine-Google`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `AppEngine-Google`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `AppEngine-Google`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `AppEngine-Google`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Google Web Preview" {
 			t.Errorf("Expected result.Name for '%s' to be 'Google Web Preview', but got '%s'", `Mozilla/5.0 (en-us) AppleWebKit/525.13 (KHTML, like Gecko; Google Web Preview) Version/3.1 Safari/525.13`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (en-us) AppleWebKit/525.13 (KHTML, like Gecko; Google Web Preview) Version/3.1 Safari/525.13`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (en-us) AppleWebKit/525.13 (KHTML, like Gecko; Google Web Preview) Version/3.1 Safari/525.13`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (en-us) AppleWebKit/525.13 (KHTML, like Gecko; Google Web Preview) Version/3.1 Safari/525.13`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_crawler_google(t *testing.T) {
 		if result.Name != "Google FeedBurner" {
 			t.Errorf("Expected result.Name for '%s' to be 'Google FeedBurner', but got '%s'", `FeedBurner/1.0 (http://www.FeedBurner.com)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `FeedBurner/1.0 (http://www.FeedBurner.com)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `FeedBurner/1.0 (http://www.FeedBurner.com)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `FeedBurner/1.0 (http://www.FeedBurner.com)`, result.Version)
 		}
 	}

--- a/crawler_nonmajor_test.go
+++ b/crawler_nonmajor_test.go
@@ -41,10 +41,9 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Os != "Windows Vista" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows Vista', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; aggregator VocusBot 0.4; +http://www.vocus.com/vnhs.html)`, result.Os)
 		}
-		/* Skip for now
 		if result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; aggregator VocusBot 0.4; +http://www.vocus.com/vnhs.html)`, result.OsVersion)
-		}*/
+		}
 		if result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; aggregator VocusBot 0.4; +http://www.vocus.com/vnhs.html)`, result.Version)
 		}

--- a/crawler_nonmajor_test.go
+++ b/crawler_nonmajor_test.go
@@ -18,13 +18,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `emBot-GalaBuzz/Nutch-1.0 (http://emining.jp/; em@galabuzz.jp)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `emBot-GalaBuzz/Nutch-1.0 (http://emining.jp/; em@galabuzz.jp)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `emBot-GalaBuzz/Nutch-1.0 (http://emining.jp/; em@galabuzz.jp)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `emBot-GalaBuzz/Nutch-1.0 (http://emining.jp/; em@galabuzz.jp)`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; aggregator VocusBot 0.4; +http://www.vocus.com/vnhs.html)`, result.Name)
 		}
-		if result.Os != "Windows Vista" {
+		if true && result.Os != "Windows Vista" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows Vista', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; aggregator VocusBot 0.4; +http://www.vocus.com/vnhs.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; aggregator VocusBot 0.4; +http://www.vocus.com/vnhs.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; aggregator VocusBot 0.4; +http://www.vocus.com/vnhs.html)`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Mozilla/5.0 (compatible; Ezooms/1.0; ezooms.bot@gmail.com)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Ezooms/1.0; ezooms.bot@gmail.com)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Ezooms/1.0; ezooms.bot@gmail.com)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Ezooms/1.0; ezooms.bot@gmail.com)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Mozilla/5.0 (compatible; Rakutenbot/1.0; +http://dynamic.rakuten.co.jp/bot.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Rakutenbot/1.0; +http://dynamic.rakuten.co.jp/bot.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Rakutenbot/1.0; +http://dynamic.rakuten.co.jp/bot.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Rakutenbot/1.0; +http://dynamic.rakuten.co.jp/bot.html)`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Flamingo_SearchEngine (+http://www.flamingosearch.com/bot)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Flamingo_SearchEngine (+http://www.flamingosearch.com/bot)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Flamingo_SearchEngine (+http://www.flamingosearch.com/bot)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Flamingo_SearchEngine (+http://www.flamingosearch.com/bot)`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `"mapion-news-bot/1.0 (http://www.mapion.co.jp/news/)"`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `"mapion-news-bot/1.0 (http://www.mapion.co.jp/news/)"`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `"mapion-news-bot/1.0 (http://www.mapion.co.jp/news/)"`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `"mapion-news-bot/1.0 (http://www.mapion.co.jp/news/)"`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Mozilla/5.0 (compatible; MJ12bot/v1.4.0; http://www.majestic12.co.uk/bot.php?+)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MJ12bot/v1.4.0; http://www.majestic12.co.uk/bot.php?+)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MJ12bot/v1.4.0; http://www.majestic12.co.uk/bot.php?+)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; MJ12bot/v1.4.0; http://www.majestic12.co.uk/bot.php?+)`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Mozilla/5.0 (compatible; TweetmemeBot/2.11; +http://tweetmeme.com/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; TweetmemeBot/2.11; +http://tweetmeme.com/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; TweetmemeBot/2.11; +http://tweetmeme.com/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; TweetmemeBot/2.11; +http://tweetmeme.com/)`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `SearQuBot/SearQuBot v1.0`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `SearQuBot/SearQuBot v1.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `SearQuBot/SearQuBot v1.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `SearQuBot/SearQuBot v1.0`, result.Version)
 		}
 	}
@@ -218,13 +218,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Mozilla/5.0 (compatible; ADJUSTbot/2.0; +http://www.ad-just.jp/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; ADJUSTbot/2.0; +http://www.ad-just.jp/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; ADJUSTbot/2.0; +http://www.ad-just.jp/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; ADJUSTbot/2.0; +http://www.ad-just.jp/)`, result.Version)
 		}
 	}
@@ -238,13 +238,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `FTRF: Friendly robot/1.3`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `FTRF: Friendly robot/1.3`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `FTRF: Friendly robot/1.3`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `FTRF: Friendly robot/1.3`, result.Version)
 		}
 	}
@@ -258,13 +258,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `kizasi-spider/1.0 (+http://kizasi.jp/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `kizasi-spider/1.0 (+http://kizasi.jp/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `kizasi-spider/1.0 (+http://kizasi.jp/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `kizasi-spider/1.0 (+http://kizasi.jp/)`, result.Version)
 		}
 	}
@@ -278,13 +278,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `BlogramCrawler/1.0.1(+http://blogram.jp/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `BlogramCrawler/1.0.1(+http://blogram.jp/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `BlogramCrawler/1.0.1(+http://blogram.jp/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `BlogramCrawler/1.0.1(+http://blogram.jp/)`, result.Version)
 		}
 	}
@@ -298,13 +298,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `www2.apserver.net ASP-Ranker Feed Crawler`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `www2.apserver.net ASP-Ranker Feed Crawler`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `www2.apserver.net ASP-Ranker Feed Crawler`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `www2.apserver.net ASP-Ranker Feed Crawler`, result.Version)
 		}
 	}
@@ -318,13 +318,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Rome Client (http://tinyurl.com/64t5n)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Rome Client (http://tinyurl.com/64t5n)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Rome Client (http://tinyurl.com/64t5n)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Rome Client (http://tinyurl.com/64t5n)`, result.Version)
 		}
 	}
@@ -338,13 +338,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `UnwindFetchor/1.0 (+http://www.gnip.com/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `UnwindFetchor/1.0 (+http://www.gnip.com/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `UnwindFetchor/1.0 (+http://www.gnip.com/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `UnwindFetchor/1.0 (+http://www.gnip.com/)`, result.Version)
 		}
 	}
@@ -358,13 +358,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `ia_archiver (+http://www.alexa.com/site/help/webmasters; crawler@alexa.com)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `ia_archiver (+http://www.alexa.com/site/help/webmasters; crawler@alexa.com)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `ia_archiver (+http://www.alexa.com/site/help/webmasters; crawler@alexa.com)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `ia_archiver (+http://www.alexa.com/site/help/webmasters; crawler@alexa.com)`, result.Version)
 		}
 	}
@@ -378,13 +378,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Summify (Summify/1.0.1; +http://summify.com)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Summify (Summify/1.0.1; +http://summify.com)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Summify (Summify/1.0.1; +http://summify.com)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Summify (Summify/1.0.1; +http://summify.com)`, result.Version)
 		}
 	}
@@ -398,13 +398,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `PostRank/2.0 (postrank.com; 1 subscribers)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `PostRank/2.0 (postrank.com; 1 subscribers)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `PostRank/2.0 (postrank.com; 1 subscribers)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `PostRank/2.0 (postrank.com; 1 subscribers)`, result.Version)
 		}
 	}
@@ -418,13 +418,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `cloudforecastbot`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `cloudforecastbot`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `cloudforecastbot`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `cloudforecastbot`, result.Version)
 		}
 	}
@@ -438,13 +438,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `SimplePie/1.3-dev (Feed Parser; http://simplepie.org; Allow like Gecko) Build/20111118194710`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `SimplePie/1.3-dev (Feed Parser; http://simplepie.org; Allow like Gecko) Build/20111118194710`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `SimplePie/1.3-dev (Feed Parser; http://simplepie.org; Allow like Gecko) Build/20111118194710`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `SimplePie/1.3-dev (Feed Parser; http://simplepie.org; Allow like Gecko) Build/20111118194710`, result.Version)
 		}
 	}
@@ -458,13 +458,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Rainmeter WebParser plugin`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Rainmeter WebParser plugin`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Rainmeter WebParser plugin`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Rainmeter WebParser plugin`, result.Version)
 		}
 	}
@@ -478,13 +478,13 @@ func Test_crawler_nonmajor(t *testing.T) {
 		if result.Name != "misc crawler" {
 			t.Errorf("Expected result.Name for '%s' to be 'misc crawler', but got '%s'", `Data-Hotel-Watchdog/1.1`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Data-Hotel-Watchdog/1.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Data-Hotel-Watchdog/1.1`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Data-Hotel-Watchdog/1.1`, result.Version)
 		}
 	}

--- a/crawler_test.go
+++ b/crawler_test.go
@@ -18,13 +18,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Slurp" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Slurp', but got '%s'", `Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Slurp" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Slurp', but got '%s'", `Mozilla/5.0 (compatible; Yahoo! Slurp/3.0; http://help.yahoo.com/help/us/ysearch/slurp)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yahoo! Slurp/3.0; http://help.yahoo.com/help/us/ysearch/slurp)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yahoo! Slurp/3.0; http://help.yahoo.com/help/us/ysearch/slurp)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yahoo! Slurp/3.0; http://help.yahoo.com/help/us/ysearch/slurp)`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Japan" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Japan', but got '%s'", `Y!J-BRO/YFSJ crawler (compatible; Mozilla 4.0; MSIE 5.5; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html; YahooFeedSeekerJp/2.0; users 0; views 248)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRO/YFSJ crawler (compatible; Mozilla 4.0; MSIE 5.5; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html; YahooFeedSeekerJp/2.0; users 0; views 248)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRO/YFSJ crawler (compatible; Mozilla 4.0; MSIE 5.5; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html; YahooFeedSeekerJp/2.0; users 0; views 248)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRO/YFSJ crawler (compatible; Mozilla 4.0; MSIE 5.5; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html; YahooFeedSeekerJp/2.0; users 0; views 248)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Japan" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Japan', but got '%s'", `Y!J-BRP/YFSBJ crawler (compatible; Mozilla 4.0; MSIE 5.5; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html; YahooFeedSeekerBetaJp/2.0; users 0; views 80)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRP/YFSBJ crawler (compatible; Mozilla 4.0; MSIE 5.5; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html; YahooFeedSeekerBetaJp/2.0; users 0; views 80)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRP/YFSBJ crawler (compatible; Mozilla 4.0; MSIE 5.5; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html; YahooFeedSeekerBetaJp/2.0; users 0; views 80)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRP/YFSBJ crawler (compatible; Mozilla 4.0; MSIE 5.5; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html; YahooFeedSeekerBetaJp/2.0; users 0; views 80)`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Japan" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Japan', but got '%s'", `Y!J-BRJ/YATS crawler (http://listing.yahoo.co.jp/support/faq/int/other/other_001.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRJ/YATS crawler (http://listing.yahoo.co.jp/support/faq/int/other/other_001.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRJ/YATS crawler (http://listing.yahoo.co.jp/support/faq/int/other/other_001.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRJ/YATS crawler (http://listing.yahoo.co.jp/support/faq/int/other/other_001.html)`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Japan" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Japan', but got '%s'", `Y!J-BRJ/YATS crawler (http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRJ/YATS crawler (http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRJ/YATS crawler (http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BRJ/YATS crawler (http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Japan" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Japan', but got '%s'", `Y!J-BSC/1.0 crawler (http://help.yahoo.co.jp/help/jp/blog-search/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BSC/1.0 crawler (http://help.yahoo.co.jp/help/jp/blog-search/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BSC/1.0 crawler (http://help.yahoo.co.jp/help/jp/blog-search/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Y!J-BSC/1.0 crawler (http://help.yahoo.co.jp/help/jp/blog-search/)`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Japan" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Japan', but got '%s'", `Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; sdk Build/GRI34; Y!J-BRZ/YATSHA crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; sdk Build/GRI34; Y!J-BRZ/YATSHA crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; sdk Build/GRI34; Y!J-BRZ/YATSHA crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; sdk Build/GRI34; Y!J-BRZ/YATSHA crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Japan" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Japan', but got '%s'", `Mozilla/5.0 (iPhone; Y!J-BRY/YATSH crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (iPhone; Y!J-BRY/YATSH crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (iPhone; Y!J-BRY/YATSH crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (iPhone; Y!J-BRY/YATSH crawler; http://help.yahoo.co.jp/help/jp/search/indexing/indexing-15.html)`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Yahoo! Pipes" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yahoo! Pipes', but got '%s'", `Yahoo Pipes 2.0`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Yahoo Pipes 2.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Yahoo Pipes 2.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Yahoo Pipes 2.0`, result.Version)
 		}
 	}
@@ -218,13 +218,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Baiduspider" {
 			t.Errorf("Expected result.Name for '%s' to be 'Baiduspider', but got '%s'", `Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)`, result.Version)
 		}
 	}
@@ -238,13 +238,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Baiduspider" {
 			t.Errorf("Expected result.Name for '%s' to be 'Baiduspider', but got '%s'", `Baiduspider+(+http://www.baidu.jp/spider/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Baiduspider+(+http://www.baidu.jp/spider/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Baiduspider+(+http://www.baidu.jp/spider/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Baiduspider+(+http://www.baidu.jp/spider/)`, result.Version)
 		}
 	}
@@ -258,13 +258,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Baiduspider" {
 			t.Errorf("Expected result.Name for '%s' to be 'Baiduspider', but got '%s'", `Baiduspider-image+(+http://www.baidu.com/search/spider.htm)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Baiduspider-image+(+http://www.baidu.com/search/spider.htm)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Baiduspider-image+(+http://www.baidu.com/search/spider.htm)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Baiduspider-image+(+http://www.baidu.com/search/spider.htm)`, result.Version)
 		}
 	}
@@ -278,13 +278,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "msnbot" {
 			t.Errorf("Expected result.Name for '%s' to be 'msnbot', but got '%s'", `msnbot/1.1 (+http://search.msn.com/msnbot.htm)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `msnbot/1.1 (+http://search.msn.com/msnbot.htm)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `msnbot/1.1 (+http://search.msn.com/msnbot.htm)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `msnbot/1.1 (+http://search.msn.com/msnbot.htm)`, result.Version)
 		}
 	}
@@ -298,13 +298,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "msnbot" {
 			t.Errorf("Expected result.Name for '%s' to be 'msnbot', but got '%s'", `msnbot-UDiscovery/2.0b (+http://search.msn.com/msnbot.htm)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `msnbot-UDiscovery/2.0b (+http://search.msn.com/msnbot.htm)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `msnbot-UDiscovery/2.0b (+http://search.msn.com/msnbot.htm)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `msnbot-UDiscovery/2.0b (+http://search.msn.com/msnbot.htm)`, result.Version)
 		}
 	}
@@ -318,13 +318,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "msnbot" {
 			t.Errorf("Expected result.Name for '%s' to be 'msnbot', but got '%s'", `msnbot/2.0b (+http://search.msn.com/msnbot.htm)._`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `msnbot/2.0b (+http://search.msn.com/msnbot.htm)._`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `msnbot/2.0b (+http://search.msn.com/msnbot.htm)._`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `msnbot/2.0b (+http://search.msn.com/msnbot.htm)._`, result.Version)
 		}
 	}
@@ -338,13 +338,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "msnbot" {
 			t.Errorf("Expected result.Name for '%s' to be 'msnbot', but got '%s'", `"msnbot-NewsBlogs/2.0b (+http://search.msn.com/msnbot.htm)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `"msnbot-NewsBlogs/2.0b (+http://search.msn.com/msnbot.htm)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `"msnbot-NewsBlogs/2.0b (+http://search.msn.com/msnbot.htm)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `"msnbot-NewsBlogs/2.0b (+http://search.msn.com/msnbot.htm)`, result.Version)
 		}
 	}
@@ -358,13 +358,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "msnbot" {
 			t.Errorf("Expected result.Name for '%s' to be 'msnbot', but got '%s'", `msnbot-media/1.1 (+http://search.msn.com/msnbot.htm)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `msnbot-media/1.1 (+http://search.msn.com/msnbot.htm)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `msnbot-media/1.1 (+http://search.msn.com/msnbot.htm)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `msnbot-media/1.1 (+http://search.msn.com/msnbot.htm)`, result.Version)
 		}
 	}
@@ -378,13 +378,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "bingbot" {
 			t.Errorf("Expected result.Name for '%s' to be 'bingbot', but got '%s'", `Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)`, result.Version)
 		}
 	}
@@ -398,13 +398,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "BingPreview" {
 			t.Errorf("Expected result.Name for '%s' to be 'BingPreview', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) BingPreview/1.0b`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) BingPreview/1.0b`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) BingPreview/1.0b`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) BingPreview/1.0b`, result.Version)
 		}
 	}
@@ -418,13 +418,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Naver Yeti" {
 			t.Errorf("Expected result.Name for '%s' to be 'Naver Yeti', but got '%s'", `Yeti/1.0 (NHN Corp.; http://help.naver.com/robots/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Yeti/1.0 (NHN Corp.; http://help.naver.com/robots/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Yeti/1.0 (NHN Corp.; http://help.naver.com/robots/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Yeti/1.0 (NHN Corp.; http://help.naver.com/robots/)`, result.Version)
 		}
 	}
@@ -438,13 +438,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Naver Yeti" {
 			t.Errorf("Expected result.Name for '%s' to be 'Naver Yeti', but got '%s'", `Mozilla/5.0 (compatible; Yeti/1.1; +http://help.naver.com/support/robots.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yeti/1.1; +http://help.naver.com/support/robots.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yeti/1.1; +http://help.naver.com/support/robots.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yeti/1.1; +http://help.naver.com/support/robots.html)`, result.Version)
 		}
 	}
@@ -458,13 +458,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Naver Yeti" {
 			t.Errorf("Expected result.Name for '%s' to be 'Naver Yeti', but got '%s'", `Mozilla/5.0 (compatible; Yeti/1.1; +http://naver.me/bot)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yeti/1.1; +http://naver.me/bot)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yeti/1.1; +http://naver.me/bot)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Yeti/1.1; +http://naver.me/bot)`, result.Version)
 		}
 	}
@@ -478,13 +478,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Indy Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'Indy Library', but got '%s'", `Mozilla/3.0 (compatible; Indy Library)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/3.0 (compatible; Indy Library)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/3.0 (compatible; Indy Library)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/3.0 (compatible; Indy Library)`, result.Version)
 		}
 	}
@@ -498,13 +498,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Apple iCloud" {
 			t.Errorf("Expected result.Name for '%s' to be 'Apple iCloud', but got '%s'", `Apple-PubSub/65.28`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Apple-PubSub/65.28`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Apple-PubSub/65.28`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Apple-PubSub/65.28`, result.Version)
 		}
 	}
@@ -518,13 +518,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "salesforce radian6" {
 			t.Errorf("Expected result.Name for '%s' to be 'salesforce radian6', but got '%s'", `R6_CommentReader(www.radian6.com/crawler)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `R6_CommentReader(www.radian6.com/crawler)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `R6_CommentReader(www.radian6.com/crawler)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `R6_CommentReader(www.radian6.com/crawler)`, result.Version)
 		}
 	}
@@ -538,13 +538,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "salesforce radian6" {
 			t.Errorf("Expected result.Name for '%s' to be 'salesforce radian6', but got '%s'", `R6_FeedFetcher(www.radian6.com/crawler)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `R6_FeedFetcher(www.radian6.com/crawler)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `R6_FeedFetcher(www.radian6.com/crawler)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `R6_FeedFetcher(www.radian6.com/crawler)`, result.Version)
 		}
 	}
@@ -558,13 +558,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Genieo Web Filter" {
 			t.Errorf("Expected result.Name for '%s' to be 'Genieo Web Filter', but got '%s'", `Mozilla/5.0 (compatible; Genieo/1.0 http://www.genieo.com/webfilter.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Genieo/1.0 http://www.genieo.com/webfilter.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Genieo/1.0 http://www.genieo.com/webfilter.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Genieo/1.0 http://www.genieo.com/webfilter.html)`, result.Version)
 		}
 	}
@@ -578,13 +578,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "topsy Butterfly" {
 			t.Errorf("Expected result.Name for '%s' to be 'topsy Butterfly', but got '%s'", `Mozilla/5.0 (compatible; Butterfly/1.0; +http://labs.topsy.com/butterfly/) Gecko/2009032608 Firefox/3.0.8`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Butterfly/1.0; +http://labs.topsy.com/butterfly/) Gecko/2009032608 Firefox/3.0.8`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Butterfly/1.0; +http://labs.topsy.com/butterfly/) Gecko/2009032608 Firefox/3.0.8`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Butterfly/1.0; +http://labs.topsy.com/butterfly/) Gecko/2009032608 Firefox/3.0.8`, result.Version)
 		}
 	}
@@ -598,13 +598,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "SeoMoz rogerbot" {
 			t.Errorf("Expected result.Name for '%s' to be 'SeoMoz rogerbot', but got '%s'", `rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler@seomoz.org)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler@seomoz.org)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler@seomoz.org)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler@seomoz.org)`, result.Version)
 		}
 	}
@@ -618,13 +618,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "SeoMoz rogerbot" {
 			t.Errorf("Expected result.Name for '%s' to be 'SeoMoz rogerbot', but got '%s'", `rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler+shiny@seomoz.org)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler+shiny@seomoz.org)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler+shiny@seomoz.org)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `rogerbot/1.0 (http://www.seomoz.org/dp/rogerbot, rogerbot-crawler+shiny@seomoz.org)`, result.Version)
 		}
 	}
@@ -638,13 +638,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "ahref AhrefsBot" {
 			t.Errorf("Expected result.Name for '%s' to be 'ahref AhrefsBot', but got '%s'", `Mozilla/5.0 (compatible; AhrefsBot/4.0; +http://ahrefs.com/robot/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; AhrefsBot/4.0; +http://ahrefs.com/robot/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; AhrefsBot/4.0; +http://ahrefs.com/robot/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; AhrefsBot/4.0; +http://ahrefs.com/robot/)`, result.Version)
 		}
 	}
@@ -658,13 +658,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Hatena" {
 			t.Errorf("Expected result.Name for '%s' to be 'Hatena', but got '%s'", `Hatena Antenna/0.5 (http://a.hatena.ne.jp/help)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Antenna/0.5 (http://a.hatena.ne.jp/help)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Antenna/0.5 (http://a.hatena.ne.jp/help)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Antenna/0.5 (http://a.hatena.ne.jp/help)`, result.Version)
 		}
 	}
@@ -678,13 +678,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Hatena" {
 			t.Errorf("Expected result.Name for '%s' to be 'Hatena', but got '%s'", `Hatena Pagetitle Agent/1.0`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Pagetitle Agent/1.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Pagetitle Agent/1.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Pagetitle Agent/1.0`, result.Version)
 		}
 	}
@@ -698,13 +698,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "Hatena" {
 			t.Errorf("Expected result.Name for '%s' to be 'Hatena', but got '%s'", `Hatena Diary RSS Module (http://d.hatena.ne.jp/help#rssmodule)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Diary RSS Module (http://d.hatena.ne.jp/help#rssmodule)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Diary RSS Module (http://d.hatena.ne.jp/help#rssmodule)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Hatena Diary RSS Module (http://d.hatena.ne.jp/help#rssmodule)`, result.Version)
 		}
 	}
@@ -718,13 +718,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "goo" {
 			t.Errorf("Expected result.Name for '%s' to be 'goo', but got '%s'", `ichiro/3.0 (http://help.goo.ne.jp/door/crawler.html)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `ichiro/3.0 (http://help.goo.ne.jp/door/crawler.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `ichiro/3.0 (http://help.goo.ne.jp/door/crawler.html)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `ichiro/3.0 (http://help.goo.ne.jp/door/crawler.html)`, result.Version)
 		}
 	}
@@ -738,13 +738,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "goo" {
 			t.Errorf("Expected result.Name for '%s' to be 'goo', but got '%s'", `DoCoMo/2.0 P900i(c100;TB;W24H11) (compatible; ichiro/mobile goo; +http://help.goo.ne.jp/help/article/1142/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 P900i(c100;TB;W24H11) (compatible; ichiro/mobile goo; +http://help.goo.ne.jp/help/article/1142/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 P900i(c100;TB;W24H11) (compatible; ichiro/mobile goo; +http://help.goo.ne.jp/help/article/1142/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 P900i(c100;TB;W24H11) (compatible; ichiro/mobile goo; +http://help.goo.ne.jp/help/article/1142/)`, result.Version)
 		}
 	}
@@ -758,13 +758,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "goo" {
 			t.Errorf("Expected result.Name for '%s' to be 'goo', but got '%s'", `gooblogsearch/2.0 (http://search.goo.ne.jp/option/use/sub4/sub4-1/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `gooblogsearch/2.0 (http://search.goo.ne.jp/option/use/sub4/sub4-1/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `gooblogsearch/2.0 (http://search.goo.ne.jp/option/use/sub4/sub4-1/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `gooblogsearch/2.0 (http://search.goo.ne.jp/option/use/sub4/sub4-1/)`, result.Version)
 		}
 	}
@@ -778,13 +778,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "livedoor FeedFetcher" {
 			t.Errorf("Expected result.Name for '%s' to be 'livedoor FeedFetcher', but got '%s'", `livedoor FeedFetcher/0.01 (http://reader.livedoor.com/; 999 subscribers)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `livedoor FeedFetcher/0.01 (http://reader.livedoor.com/; 999 subscribers)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `livedoor FeedFetcher/0.01 (http://reader.livedoor.com/; 999 subscribers)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `livedoor FeedFetcher/0.01 (http://reader.livedoor.com/; 999 subscribers)`, result.Version)
 		}
 	}
@@ -798,13 +798,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "livedoor FeedFetcher" {
 			t.Errorf("Expected result.Name for '%s' to be 'livedoor FeedFetcher', but got '%s'", `Fastladder FeedFetcher/0.01 (http://fastladder.com/; 27 subscribers)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Fastladder FeedFetcher/0.01 (http://fastladder.com/; 27 subscribers)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Fastladder FeedFetcher/0.01 (http://fastladder.com/; 27 subscribers)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Fastladder FeedFetcher/0.01 (http://fastladder.com/; 27 subscribers)`, result.Version)
 		}
 	}
@@ -818,13 +818,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "twitter" {
 			t.Errorf("Expected result.Name for '%s' to be 'twitter', but got '%s'", `Twitterbot/1.0`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Twitterbot/1.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Twitterbot/1.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Twitterbot/1.0`, result.Version)
 		}
 	}
@@ -838,13 +838,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "facebook" {
 			t.Errorf("Expected result.Name for '%s' to be 'facebook', but got '%s'", `facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)`, result.Version)
 		}
 	}
@@ -858,13 +858,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "mixi" {
 			t.Errorf("Expected result.Name for '%s' to be 'mixi', but got '%s'", `mixi-check/1.0 (http://mixi.jp/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `mixi-check/1.0 (http://mixi.jp/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `mixi-check/1.0 (http://mixi.jp/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `mixi-check/1.0 (http://mixi.jp/)`, result.Version)
 		}
 	}
@@ -878,13 +878,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "mixi" {
 			t.Errorf("Expected result.Name for '%s' to be 'mixi', but got '%s'", `mixi-news-crawler/1.00 (http://mixi.jp/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `mixi-news-crawler/1.00 (http://mixi.jp/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `mixi-news-crawler/1.00 (http://mixi.jp/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `mixi-news-crawler/1.00 (http://mixi.jp/)`, result.Version)
 		}
 	}
@@ -898,13 +898,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "mixi" {
 			t.Errorf("Expected result.Name for '%s' to be 'mixi', but got '%s'", `mixi-crawler/2.00 (http://mixi.jp/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `mixi-crawler/2.00 (http://mixi.jp/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `mixi-crawler/2.00 (http://mixi.jp/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `mixi-crawler/2.00 (http://mixi.jp/)`, result.Version)
 		}
 	}
@@ -918,13 +918,13 @@ func Test_crawler(t *testing.T) {
 		if result.Name != "trendiction" {
 			t.Errorf("Expected result.Name for '%s' to be 'trendiction', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.0; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20071127 Firefox/3.0.0.11`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.0; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20071127 Firefox/3.0.0.11`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.0; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20071127 Firefox/3.0.0.11`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.0; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20071127 Firefox/3.0.0.11`, result.Version)
 		}
 	}

--- a/maint/gendataset.go
+++ b/maint/gendataset.go
@@ -136,12 +136,28 @@ func Test_{{.TestName}}(t *testing.T) {
 `
 
 	for _, field := range []string{"Category", "Name", "Os", "OsVersion", "Version"} {
-		tmpl += fmt.Sprintf(`		if result.%s != "{{.%s}}" {
+		if field == "Os" {
+			tmpl += fmt.Sprintf(`       if {{.CheckOs}} && result.%s != "{{.%s}}" {
 			t.Errorf("Expected result.%s for '%%s' to be '{{.%s}}', but got '%%s'", `+"`{{.Target}}`"+`, result.%s)
 		}
 `, field, field, field, field, field)
+		} else if field == "OsVersion" {
+			tmpl += fmt.Sprintf(`       if {{.CheckOsVersion}} && result.%s != "{{.%s}}" {
+			t.Errorf("Expected result.%s for '%%s' to be '{{.%s}}', but got '%%s'", `+"`{{.Target}}`"+`, result.%s)
+		}
+`, field, field, field, field, field)
+		} else if field == "Version" {
+			tmpl += fmt.Sprintf(`       if {{.CheckVersion}} && result.%s != "{{.%s}}" {
+			t.Errorf("Expected result.%s for '%%s' to be '{{.%s}}', but got '%%s'", `+"`{{.Target}}`"+`, result.%s)
+		}
+`, field, field, field, field, field)
+		} else {
+			tmpl += fmt.Sprintf(`		if result.%s != "{{.%s}}" {
+			t.Errorf("Expected result.%s for '%%s' to be '{{.%s}}', but got '%%s'", `+"`{{.Target}}`"+`, result.%s)
+		}
+`, field, field, field, field, field)
+		}
 	}
-
 	tmpl += `	}
 {{end}}
 }
@@ -178,12 +194,15 @@ func Test_{{.TestName}}(t *testing.T) {
 		var data struct {
 			TestName string
 			Tests    []*struct {
-				Target    string
-				Name      string
-				Os        string
-				OsVersion string `yaml:"os_version,omitempty"`
-				Category  string
-				Version   string
+				Target         string
+				Name           string
+				Os             string
+				OsVersion      string `yaml:"os_version,omitempty"`
+				Category       string
+				Version        string
+				CheckOs        bool
+				CheckOsVersion bool
+				CheckVersion   bool
 			}
 		}
 
@@ -214,15 +233,21 @@ func Test_{{.TestName}}(t *testing.T) {
 			}
 			if d.Os == "" {
 				d.Os = "UNKNOWN"
+				d.CheckOs = false
+			} else {
+				d.CheckOs = true
 			}
 			if d.Version == "" {
 				d.Version = "UNKNOWN"
+				d.CheckVersion = false
+			} else {
+				d.CheckVersion = true
 			}
 			if d.OsVersion == "" {
 				d.OsVersion = "UNKNOWN"
-			}
-			if d.Version == "" {
-				d.Version = "UNKNOWN"
+				d.CheckOsVersion = false
+			} else {
+				d.CheckOsVersion = true
 			}
 		}
 

--- a/misc_test.go
+++ b/misc_test.go
@@ -18,13 +18,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "Safari RSSReader" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari RSSReader', but got '%s'", `AppleSyndication/56.1`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `AppleSyndication/56.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `AppleSyndication/56.1`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `AppleSyndication/56.1`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "Google Desktop" {
 			t.Errorf("Expected result.Name for '%s' to be 'Google Desktop', but got '%s'", `Mozilla/5.0 (compatible; Google Desktop/5.9.1005.12335; http://desktop.google.com/)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Google Desktop/5.9.1005.12335; http://desktop.google.com/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Google Desktop/5.9.1005.12335; http://desktop.google.com/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; Google Desktop/5.9.1005.12335; http://desktop.google.com/)`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "Windows RSSReader" {
 			t.Errorf("Expected result.Name for '%s' to be 'Windows RSSReader', but got '%s'", `Windows-RSS-Platform/2.0 (MSIE 9.0; Windows NT 6.0)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if false && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Windows-RSS-Platform/2.0 (MSIE 9.0; Windows NT 6.0)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Windows-RSS-Platform/2.0 (MSIE 9.0; Windows NT 6.0)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Windows-RSS-Platform/2.0 (MSIE 9.0; Windows NT 6.0)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "RSSReader" {
 			t.Errorf("Expected result.Name for '%s' to be 'RSSReader', but got '%s'", `RssBar/1.29 (RssBar for unDonut 1.35)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `RssBar/1.29 (RssBar for unDonut 1.35)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `RssBar/1.29 (RssBar for unDonut 1.35)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `RssBar/1.29 (RssBar for unDonut 1.35)`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "RSSReader" {
 			t.Errorf("Expected result.Name for '%s' to be 'RSSReader', but got '%s'", `MagpieRSS/0.61 (+http://magpierss.sf.net)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `MagpieRSS/0.61 (+http://magpierss.sf.net)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `MagpieRSS/0.61 (+http://magpierss.sf.net)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `MagpieRSS/0.61 (+http://magpierss.sf.net)`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "RSSReader" {
 			t.Errorf("Expected result.Name for '%s' to be 'RSSReader', but got '%s'", `gooRSSreader3.7 - build20090410`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `gooRSSreader3.7 - build20090410`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `gooRSSreader3.7 - build20090410`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `gooRSSreader3.7 - build20090410`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "RSSReader" {
 			t.Errorf("Expected result.Name for '%s' to be 'RSSReader', but got '%s'", `Fenrir Headline-Reader Plugin`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Fenrir Headline-Reader Plugin`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Fenrir Headline-Reader Plugin`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Fenrir Headline-Reader Plugin`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "RSSReader" {
 			t.Errorf("Expected result.Name for '%s' to be 'RSSReader', but got '%s'", `jsRSS++/3.15`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `jsRSS++/3.15`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `jsRSS++/3.15`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `jsRSS++/3.15`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "RSSReader" {
 			t.Errorf("Expected result.Name for '%s' to be 'RSSReader', but got '%s'", `cococ/1.06`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `cococ/1.06`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `cococ/1.06`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `cococ/1.06`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Wget/1.12 (linux-gnu)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Wget/1.12 (linux-gnu)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Wget/1.12 (linux-gnu)`, result.OsVersion)
 		}
-		if result.Version != "wget" {
+		if true && result.Version != "wget" {
 			t.Errorf("Expected result.Version for '%s' to be 'wget', but got '%s'", `Wget/1.12 (linux-gnu)`, result.Version)
 		}
 	}
@@ -218,13 +218,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Apache-HttpClient/UNAVAILABLE (java 1.4)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Apache-HttpClient/UNAVAILABLE (java 1.4)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Apache-HttpClient/UNAVAILABLE (java 1.4)`, result.OsVersion)
 		}
-		if result.Version != "Java" {
+		if true && result.Version != "Java" {
 			t.Errorf("Expected result.Version for '%s' to be 'Java', but got '%s'", `Apache-HttpClient/UNAVAILABLE (java 1.4)`, result.Version)
 		}
 	}
@@ -238,13 +238,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `livedoor HttpClient`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `livedoor HttpClient`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `livedoor HttpClient`, result.OsVersion)
 		}
-		if result.Version != "Java" {
+		if true && result.Version != "Java" {
 			t.Errorf("Expected result.Version for '%s' to be 'Java', but got '%s'", `livedoor HttpClient`, result.Version)
 		}
 	}
@@ -258,13 +258,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Jakarta Commons-HttpClient/3.0`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Jakarta Commons-HttpClient/3.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Jakarta Commons-HttpClient/3.0`, result.OsVersion)
 		}
-		if result.Version != "Java" {
+		if true && result.Version != "Java" {
 			t.Errorf("Expected result.Version for '%s' to be 'Java', but got '%s'", `Jakarta Commons-HttpClient/3.0`, result.Version)
 		}
 	}
@@ -278,13 +278,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Java/1.5.0_17`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Java/1.5.0_17`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Java/1.5.0_17`, result.OsVersion)
 		}
-		if result.Version != "Java" {
+		if true && result.Version != "Java" {
 			t.Errorf("Expected result.Version for '%s' to be 'Java', but got '%s'", `Java/1.5.0_17`, result.Version)
 		}
 	}
@@ -298,13 +298,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `IE6.0,Java(TM) 2 Runtime Environment, Standard Edition`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `IE6.0,Java(TM) 2 Runtime Environment, Standard Edition`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `IE6.0,Java(TM) 2 Runtime Environment, Standard Edition`, result.OsVersion)
 		}
-		if result.Version != "Java" {
+		if true && result.Version != "Java" {
 			t.Errorf("Expected result.Version for '%s' to be 'Java', but got '%s'", `IE6.0,Java(TM) 2 Runtime Environment, Standard Edition`, result.Version)
 		}
 	}
@@ -318,13 +318,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `libwww-perl/5.835`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `libwww-perl/5.835`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `libwww-perl/5.835`, result.OsVersion)
 		}
-		if result.Version != "perl" {
+		if true && result.Version != "perl" {
 			t.Errorf("Expected result.Version for '%s' to be 'perl', but got '%s'", `libwww-perl/5.835`, result.Version)
 		}
 	}
@@ -338,13 +338,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `WWW-Mechanize/1.64`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `WWW-Mechanize/1.64`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `WWW-Mechanize/1.64`, result.OsVersion)
 		}
-		if result.Version != "perl" {
+		if true && result.Version != "perl" {
 			t.Errorf("Expected result.Version for '%s' to be 'perl', but got '%s'", `WWW-Mechanize/1.64`, result.Version)
 		}
 	}
@@ -358,13 +358,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `LWP::Simple/5.800`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `LWP::Simple/5.800`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `LWP::Simple/5.800`, result.OsVersion)
 		}
-		if result.Version != "perl" {
+		if true && result.Version != "perl" {
 			t.Errorf("Expected result.Version for '%s' to be 'perl', but got '%s'", `LWP::Simple/5.800`, result.Version)
 		}
 	}
@@ -378,13 +378,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `LWP LDMusicNews::LDNewsAPI`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `LWP LDMusicNews::LDNewsAPI`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `LWP LDMusicNews::LDNewsAPI`, result.OsVersion)
 		}
-		if result.Version != "perl" {
+		if true && result.Version != "perl" {
 			t.Errorf("Expected result.Version for '%s' to be 'perl', but got '%s'", `LWP LDMusicNews::LDNewsAPI`, result.Version)
 		}
 	}
@@ -398,13 +398,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `lwp-trivial/1.41`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `lwp-trivial/1.41`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `lwp-trivial/1.41`, result.OsVersion)
 		}
-		if result.Version != "perl" {
+		if true && result.Version != "perl" {
 			t.Errorf("Expected result.Version for '%s' to be 'perl', but got '%s'", `lwp-trivial/1.41`, result.Version)
 		}
 	}
@@ -418,13 +418,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Ruby`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Ruby`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Ruby`, result.OsVersion)
 		}
-		if result.Version != "ruby" {
+		if true && result.Version != "ruby" {
 			t.Errorf("Expected result.Version for '%s' to be 'ruby', but got '%s'", `Ruby`, result.Version)
 		}
 	}
@@ -438,13 +438,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `feedzirra http://github.com/pauldix/feedzirra/tree/master`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `feedzirra http://github.com/pauldix/feedzirra/tree/master`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `feedzirra http://github.com/pauldix/feedzirra/tree/master`, result.OsVersion)
 		}
-		if result.Version != "ruby" {
+		if true && result.Version != "ruby" {
 			t.Errorf("Expected result.Version for '%s' to be 'ruby', but got '%s'", `feedzirra http://github.com/pauldix/feedzirra/tree/master`, result.Version)
 		}
 	}
@@ -458,13 +458,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Typhoeus - https://github.com/typhoeus/typhoeus`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Typhoeus - https://github.com/typhoeus/typhoeus`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Typhoeus - https://github.com/typhoeus/typhoeus`, result.OsVersion)
 		}
-		if result.Version != "ruby" {
+		if true && result.Version != "ruby" {
 			t.Errorf("Expected result.Version for '%s' to be 'ruby', but got '%s'", `Typhoeus - https://github.com/typhoeus/typhoeus`, result.Version)
 		}
 	}
@@ -478,13 +478,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Python-urllib/1.16`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Python-urllib/1.16`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Python-urllib/1.16`, result.OsVersion)
 		}
-		if result.Version != "python" {
+		if true && result.Version != "python" {
 			t.Errorf("Expected result.Version for '%s' to be 'python', but got '%s'", `Python-urllib/1.16`, result.Version)
 		}
 	}
@@ -498,13 +498,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Twisted PageGetter`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Twisted PageGetter`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Twisted PageGetter`, result.OsVersion)
 		}
-		if result.Version != "python" {
+		if true && result.Version != "python" {
 			t.Errorf("Expected result.Version for '%s' to be 'python', but got '%s'", `Twisted PageGetter`, result.Version)
 		}
 	}
@@ -518,13 +518,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `PHP/5.2.13`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `PHP/5.2.13`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `PHP/5.2.13`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `PHP/5.2.13`, result.Version)
 		}
 	}
@@ -538,13 +538,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `PHP`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `PHP`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `PHP`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `PHP`, result.Version)
 		}
 	}
@@ -558,13 +558,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `PEAR HTTP_Request class`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `PEAR HTTP_Request class`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `PEAR HTTP_Request class`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `PEAR HTTP_Request class`, result.Version)
 		}
 	}
@@ -578,13 +578,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `HTTP_Request2/2.1.1 (http://pear.php.net/package/http_request2) PHP/5.3.10-1ubuntu3.6`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `HTTP_Request2/2.1.1 (http://pear.php.net/package/http_request2) PHP/5.3.10-1ubuntu3.6`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `HTTP_Request2/2.1.1 (http://pear.php.net/package/http_request2) PHP/5.3.10-1ubuntu3.6`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `HTTP_Request2/2.1.1 (http://pear.php.net/package/http_request2) PHP/5.3.10-1ubuntu3.6`, result.Version)
 		}
 	}
@@ -598,13 +598,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `PECL::HTTP/1.7.4 (PHP/5.4.4)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `PECL::HTTP/1.7.4 (PHP/5.4.4)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `PECL::HTTP/1.7.4 (PHP/5.4.4)`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `PECL::HTTP/1.7.4 (PHP/5.4.4)`, result.Version)
 		}
 	}
@@ -618,13 +618,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `WordPress/3.2.1; http://www.painlog.jp`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `WordPress/3.2.1; http://www.painlog.jp`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `WordPress/3.2.1; http://www.painlog.jp`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `WordPress/3.2.1; http://www.painlog.jp`, result.Version)
 		}
 	}
@@ -638,13 +638,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `CakePHP`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `CakePHP`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `CakePHP`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `CakePHP`, result.Version)
 		}
 	}
@@ -658,13 +658,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `PukiWiki/1.4.6`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `PukiWiki/1.4.6`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `PukiWiki/1.4.6`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `PukiWiki/1.4.6`, result.Version)
 		}
 	}
@@ -678,13 +678,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `Mozilla/5.0 (compatible; PEAR HTTP_Request class;)`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; PEAR HTTP_Request class;)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; PEAR HTTP_Request class;)`, result.OsVersion)
 		}
-		if result.Version != "php" {
+		if true && result.Version != "php" {
 			t.Errorf("Expected result.Version for '%s' to be 'php', but got '%s'", `Mozilla/5.0 (compatible; PEAR HTTP_Request class;)`, result.Version)
 		}
 	}
@@ -698,13 +698,13 @@ func Test_misc(t *testing.T) {
 		if result.Name != "HTTP Library" {
 			t.Errorf("Expected result.Name for '%s' to be 'HTTP Library', but got '%s'", `curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.19.1 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2`, result.Name)
 		}
-		if result.Os != "UNKNOWN" {
+		if true && result.Os != "UNKNOWN" {
 			t.Errorf("Expected result.Os for '%s' to be 'UNKNOWN', but got '%s'", `curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.19.1 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.19.1 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2`, result.OsVersion)
 		}
-		if result.Version != "curl" {
+		if true && result.Version != "curl" {
 			t.Errorf("Expected result.Version for '%s' to be 'curl', but got '%s'", `curl/7.19.7 (x86_64-redhat-linux-gnu) libcurl/7.19.7 NSS/3.19.1 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2`, result.Version)
 		}
 	}

--- a/mobilephone_au_test.go
+++ b/mobilephone_au_test.go
@@ -18,13 +18,13 @@ func Test_mobilephone_au(t *testing.T) {
 		if result.Name != "au by KDDI" {
 			t.Errorf("Expected result.Name for '%s' to be 'au by KDDI', but got '%s'", `KDDI-TS3V UP.Browser/6.2_7.2.7.1.K.6.210 (GUI) MMP/2.0`, result.Name)
 		}
-		if result.Os != "au" {
+		if true && result.Os != "au" {
 			t.Errorf("Expected result.Os for '%s' to be 'au', but got '%s'", `KDDI-TS3V UP.Browser/6.2_7.2.7.1.K.6.210 (GUI) MMP/2.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `KDDI-TS3V UP.Browser/6.2_7.2.7.1.K.6.210 (GUI) MMP/2.0`, result.OsVersion)
 		}
-		if result.Version != "TS3V" {
+		if true && result.Version != "TS3V" {
 			t.Errorf("Expected result.Version for '%s' to be 'TS3V', but got '%s'", `KDDI-TS3V UP.Browser/6.2_7.2.7.1.K.6.210 (GUI) MMP/2.0`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_mobilephone_au(t *testing.T) {
 		if result.Name != "au by KDDI" {
 			t.Errorf("Expected result.Name for '%s' to be 'au by KDDI', but got '%s'", `KDDI-CA3H UP.Browser/6.2_7.2.7.1.K.5.207 (GUI) MMP/2.0`, result.Name)
 		}
-		if result.Os != "au" {
+		if true && result.Os != "au" {
 			t.Errorf("Expected result.Os for '%s' to be 'au', but got '%s'", `KDDI-CA3H UP.Browser/6.2_7.2.7.1.K.5.207 (GUI) MMP/2.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `KDDI-CA3H UP.Browser/6.2_7.2.7.1.K.5.207 (GUI) MMP/2.0`, result.OsVersion)
 		}
-		if result.Version != "CA3H" {
+		if true && result.Version != "CA3H" {
 			t.Errorf("Expected result.Version for '%s' to be 'CA3H', but got '%s'", `KDDI-CA3H UP.Browser/6.2_7.2.7.1.K.5.207 (GUI) MMP/2.0`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_mobilephone_au(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Mozilla/5.0 Opera/9.5 (KDDI-SH3F; BREW; Opera Mobi; U; ja) Presto/2.2.1`, result.Name)
 		}
-		if result.Os != "au" {
+		if true && result.Os != "au" {
 			t.Errorf("Expected result.Os for '%s' to be 'au', but got '%s'", `Mozilla/5.0 Opera/9.5 (KDDI-SH3F; BREW; Opera Mobi; U; ja) Presto/2.2.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 Opera/9.5 (KDDI-SH3F; BREW; Opera Mobi; U; ja) Presto/2.2.1`, result.OsVersion)
 		}
-		if result.Version != "SH3F" {
+		if true && result.Version != "SH3F" {
 			t.Errorf("Expected result.Version for '%s' to be 'SH3F', but got '%s'", `Mozilla/5.0 Opera/9.5 (KDDI-SH3F; BREW; Opera Mobi; U; ja) Presto/2.2.1`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_mobilephone_au(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; KDDI-CA3B) Opera 8.60 [ja]`, result.Name)
 		}
-		if result.Os != "au" {
+		if true && result.Os != "au" {
 			t.Errorf("Expected result.Os for '%s' to be 'au', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; KDDI-CA3B) Opera 8.60 [ja]`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; KDDI-CA3B) Opera 8.60 [ja]`, result.OsVersion)
 		}
-		if result.Version != "CA3B" {
+		if true && result.Version != "CA3B" {
 			t.Errorf("Expected result.Version for '%s' to be 'CA3B', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; KDDI-CA3B) Opera 8.60 [ja]`, result.Version)
 		}
 	}

--- a/mobilephone_docomo_test.go
+++ b/mobilephone_docomo_test.go
@@ -18,13 +18,13 @@ func Test_mobilephone_docomo(t *testing.T) {
 		if result.Name != "docomo" {
 			t.Errorf("Expected result.Name for '%s' to be 'docomo', but got '%s'", `DoCoMo/2.0 SH01A(c100;TB;W24H16)`, result.Name)
 		}
-		if result.Os != "docomo" {
+		if true && result.Os != "docomo" {
 			t.Errorf("Expected result.Os for '%s' to be 'docomo', but got '%s'", `DoCoMo/2.0 SH01A(c100;TB;W24H16)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 SH01A(c100;TB;W24H16)`, result.OsVersion)
 		}
-		if result.Version != "SH01A" {
+		if true && result.Version != "SH01A" {
 			t.Errorf("Expected result.Version for '%s' to be 'SH01A', but got '%s'", `DoCoMo/2.0 SH01A(c100;TB;W24H16)`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_mobilephone_docomo(t *testing.T) {
 		if result.Name != "docomo" {
 			t.Errorf("Expected result.Name for '%s' to be 'docomo', but got '%s'", `DoCoMo/2.0 N07B(c500;TB;W24H16)`, result.Name)
 		}
-		if result.Os != "docomo" {
+		if true && result.Os != "docomo" {
 			t.Errorf("Expected result.Os for '%s' to be 'docomo', but got '%s'", `DoCoMo/2.0 N07B(c500;TB;W24H16)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/2.0 N07B(c500;TB;W24H16)`, result.OsVersion)
 		}
-		if result.Version != "N07B" {
+		if true && result.Version != "N07B" {
 			t.Errorf("Expected result.Version for '%s' to be 'N07B', but got '%s'", `DoCoMo/2.0 N07B(c500;TB;W24H16)`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_mobilephone_docomo(t *testing.T) {
 		if result.Name != "docomo" {
 			t.Errorf("Expected result.Name for '%s' to be 'docomo', but got '%s'", `Mozilla/5.0 (compatible; DoCoMo/1.0/D505i/c20/TB/W20H10; http://www.rcdtokyo.com/pc2m/)`, result.Name)
 		}
-		if result.Os != "docomo" {
+		if true && result.Os != "docomo" {
 			t.Errorf("Expected result.Os for '%s' to be 'docomo', but got '%s'", `Mozilla/5.0 (compatible; DoCoMo/1.0/D505i/c20/TB/W20H10; http://www.rcdtokyo.com/pc2m/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; DoCoMo/1.0/D505i/c20/TB/W20H10; http://www.rcdtokyo.com/pc2m/)`, result.OsVersion)
 		}
-		if result.Version != "D505i" {
+		if true && result.Version != "D505i" {
 			t.Errorf("Expected result.Version for '%s' to be 'D505i', but got '%s'", `Mozilla/5.0 (compatible; DoCoMo/1.0/D505i/c20/TB/W20H10; http://www.rcdtokyo.com/pc2m/)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_mobilephone_docomo(t *testing.T) {
 		if result.Name != "docomo" {
 			t.Errorf("Expected result.Name for '%s' to be 'docomo', but got '%s'", `DoCoMo/1.0/N505i/c20/TB/W24H12`, result.Name)
 		}
-		if result.Os != "docomo" {
+		if true && result.Os != "docomo" {
 			t.Errorf("Expected result.Os for '%s' to be 'docomo', but got '%s'", `DoCoMo/1.0/N505i/c20/TB/W24H12`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `DoCoMo/1.0/N505i/c20/TB/W24H12`, result.OsVersion)
 		}
-		if result.Version != "N505i" {
+		if true && result.Version != "N505i" {
 			t.Errorf("Expected result.Version for '%s' to be 'N505i', but got '%s'", `DoCoMo/1.0/N505i/c20/TB/W24H12`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_mobilephone_docomo(t *testing.T) {
 		if result.Name != "docomo" {
 			t.Errorf("Expected result.Name for '%s' to be 'docomo', but got '%s'", `Mozilla/4.08 (N905imyu_W;FOMA;c500;TB)`, result.Name)
 		}
-		if result.Os != "docomo" {
+		if true && result.Os != "docomo" {
 			t.Errorf("Expected result.Os for '%s' to be 'docomo', but got '%s'", `Mozilla/4.08 (N905imyu_W;FOMA;c500;TB)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.08 (N905imyu_W;FOMA;c500;TB)`, result.OsVersion)
 		}
-		if result.Version != "N905imyu_W" {
+		if true && result.Version != "N905imyu_W" {
 			t.Errorf("Expected result.Version for '%s' to be 'N905imyu_W', but got '%s'", `Mozilla/4.08 (N905imyu_W;FOMA;c500;TB)`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_mobilephone_docomo(t *testing.T) {
 		if result.Name != "docomo" {
 			t.Errorf("Expected result.Name for '%s' to be 'docomo', but got '%s'", `Mozilla/5.0 (F02B;FOMA;like Gecko)`, result.Name)
 		}
-		if result.Os != "docomo" {
+		if true && result.Os != "docomo" {
 			t.Errorf("Expected result.Os for '%s' to be 'docomo', but got '%s'", `Mozilla/5.0 (F02B;FOMA;like Gecko)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (F02B;FOMA;like Gecko)`, result.OsVersion)
 		}
-		if result.Version != "F02B" {
+		if true && result.Version != "F02B" {
 			t.Errorf("Expected result.Version for '%s' to be 'F02B', but got '%s'", `Mozilla/5.0 (F02B;FOMA;like Gecko)`, result.Version)
 		}
 	}

--- a/mobilephone_misc_test.go
+++ b/mobilephone_misc_test.go
@@ -18,13 +18,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "jig browser" {
 			t.Errorf("Expected result.Name for '%s' to be 'jig browser', but got '%s'", `Mozilla/5.0 (jig browser core; SH03B)`, result.Name)
 		}
-		if result.Os != "jig" {
+		if true && result.Os != "jig" {
 			t.Errorf("Expected result.Os for '%s' to be 'jig', but got '%s'", `Mozilla/5.0 (jig browser core; SH03B)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (jig browser core; SH03B)`, result.OsVersion)
 		}
-		if result.Version != "SH03B" {
+		if true && result.Version != "SH03B" {
 			t.Errorf("Expected result.Version for '%s' to be 'SH03B', but got '%s'", `Mozilla/5.0 (jig browser core; SH03B)`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "jig browser" {
 			t.Errorf("Expected result.Name for '%s' to be 'jig browser', but got '%s'", `Mozilla/4.0 (jig browser9i 1.5.0; F10B; 2004)`, result.Name)
 		}
-		if result.Os != "jig" {
+		if true && result.Os != "jig" {
 			t.Errorf("Expected result.Os for '%s' to be 'jig', but got '%s'", `Mozilla/4.0 (jig browser9i 1.5.0; F10B; 2004)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.0 (jig browser9i 1.5.0; F10B; 2004)`, result.OsVersion)
 		}
-		if result.Version != "F10B" {
+		if true && result.Version != "F10B" {
 			t.Errorf("Expected result.Version for '%s' to be 'F10B', but got '%s'", `Mozilla/4.0 (jig browser9i 1.5.0; F10B; 2004)`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "jig browser" {
 			t.Errorf("Expected result.Name for '%s' to be 'jig browser', but got '%s'", `Mozilla/4.0 (jig browser9)`, result.Name)
 		}
-		if result.Os != "jig" {
+		if true && result.Os != "jig" {
 			t.Errorf("Expected result.Os for '%s' to be 'jig', but got '%s'", `Mozilla/4.0 (jig browser9)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.0 (jig browser9)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if true && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.0 (jig browser9)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "emobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'emobile', but got '%s'", `emobile/1.0.0 (H11T; like Gecko; Wireless) NetFront/3.4`, result.Name)
 		}
-		if result.Os != "emobile" {
+		if true && result.Os != "emobile" {
 			t.Errorf("Expected result.Os for '%s' to be 'emobile', but got '%s'", `emobile/1.0.0 (H11T; like Gecko; Wireless) NetFront/3.4`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `emobile/1.0.0 (H11T; like Gecko; Wireless) NetFront/3.4`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `emobile/1.0.0 (H11T; like Gecko; Wireless) NetFront/3.4`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "emobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'emobile', but got '%s'", `IAC/1.0 (H31IA;like Gecko;OpenBrowser) WWW Browser/ver1.0`, result.Name)
 		}
-		if result.Os != "emobile" {
+		if true && result.Os != "emobile" {
 			t.Errorf("Expected result.Os for '%s' to be 'emobile', but got '%s'", `IAC/1.0 (H31IA;like Gecko;OpenBrowser) WWW Browser/ver1.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `IAC/1.0 (H31IA;like Gecko;OpenBrowser) WWW Browser/ver1.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `IAC/1.0 (H31IA;like Gecko;OpenBrowser) WWW Browser/ver1.0`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "emobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'emobile', but got '%s'", `Mozilla/5.0 (H11T; like Gecko; OpenBrowser) NetFront/3.4`, result.Name)
 		}
-		if result.Os != "emobile" {
+		if true && result.Os != "emobile" {
 			t.Errorf("Expected result.Os for '%s' to be 'emobile', but got '%s'", `Mozilla/5.0 (H11T; like Gecko; OpenBrowser) NetFront/3.4`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (H11T; like Gecko; OpenBrowser) NetFront/3.4`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (H11T; like Gecko; OpenBrowser) NetFront/3.4`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "emobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'emobile', but got '%s'", `Huawei/1.0/H12HW/B000 Browser/Obigo-Browser/Q04A`, result.Name)
 		}
-		if result.Os != "emobile" {
+		if true && result.Os != "emobile" {
 			t.Errorf("Expected result.Os for '%s' to be 'emobile', but got '%s'", `Huawei/1.0/H12HW/B000 Browser/Obigo-Browser/Q04A`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Huawei/1.0/H12HW/B000 Browser/Obigo-Browser/Q04A`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Huawei/1.0/H12HW/B000 Browser/Obigo-Browser/Q04A`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NokiaE66-1/500.21.009; Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413`, result.Name)
 		}
-		if result.Os != "SymbianOS" {
+		if true && result.Os != "SymbianOS" {
 			t.Errorf("Expected result.Os for '%s' to be 'SymbianOS', but got '%s'", `Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NokiaE66-1/500.21.009; Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NokiaE66-1/500.21.009; Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if true && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (SymbianOS/9.2; U; Series60/3.1 NokiaE66-1/500.21.009; Profile/MIDP-2.0 Configuration/CLDC-1.1 ) AppleWebKit/413 (KHTML, like Gecko) Safari/413`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "Mobile Transcoder" {
 			t.Errorf("Expected result.Name for '%s' to be 'Mobile Transcoder', but got '%s'", `Mozilla/5.0 (en-us) AppleWebKit/534.14 (KHTML, like Gecko; Google Wireless Transcoder) Chrome/9.0.597 Safari/534.14`, result.Name)
 		}
-		if result.Os != "Mobile Transcoder" {
+		if true && result.Os != "Mobile Transcoder" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mobile Transcoder', but got '%s'", `Mozilla/5.0 (en-us) AppleWebKit/534.14 (KHTML, like Gecko; Google Wireless Transcoder) Chrome/9.0.597 Safari/534.14`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (en-us) AppleWebKit/534.14 (KHTML, like Gecko; Google Wireless Transcoder) Chrome/9.0.597 Safari/534.14`, result.OsVersion)
 		}
-		if result.Version != "Google" {
+		if true && result.Version != "Google" {
 			t.Errorf("Expected result.Version for '%s' to be 'Google', but got '%s'", `Mozilla/5.0 (en-us) AppleWebKit/534.14 (KHTML, like Gecko; Google Wireless Transcoder) Chrome/9.0.597 Safari/534.14`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_mobilephone_misc(t *testing.T) {
 		if result.Name != "Mobile Transcoder" {
 			t.Errorf("Expected result.Name for '%s' to be 'Mobile Transcoder', but got '%s'", `Mozilla/5.0 (compatible; livedoor-Mobile-Gateway/0.02; +http://p.m.livedoor.com/help.html)`, result.Name)
 		}
-		if result.Os != "Mobile Transcoder" {
+		if true && result.Os != "Mobile Transcoder" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mobile Transcoder', but got '%s'", `Mozilla/5.0 (compatible; livedoor-Mobile-Gateway/0.02; +http://p.m.livedoor.com/help.html)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (compatible; livedoor-Mobile-Gateway/0.02; +http://p.m.livedoor.com/help.html)`, result.OsVersion)
 		}
-		if result.Version != "livedoor" {
+		if true && result.Version != "livedoor" {
 			t.Errorf("Expected result.Version for '%s' to be 'livedoor', but got '%s'", `Mozilla/5.0 (compatible; livedoor-Mobile-Gateway/0.02; +http://p.m.livedoor.com/help.html)`, result.Version)
 		}
 	}

--- a/mobilephone_softbank_test.go
+++ b/mobilephone_softbank_test.go
@@ -18,13 +18,13 @@ func Test_mobilephone_softbank(t *testing.T) {
 		if result.Name != "SoftBank Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'SoftBank Mobile', but got '%s'", `SoftBank/1.0/841SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Name)
 		}
-		if result.Os != "SoftBank" {
+		if true && result.Os != "SoftBank" {
 			t.Errorf("Expected result.Os for '%s' to be 'SoftBank', but got '%s'", `SoftBank/1.0/841SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `SoftBank/1.0/841SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.OsVersion)
 		}
-		if result.Version != "841SH" {
+		if true && result.Version != "841SH" {
 			t.Errorf("Expected result.Version for '%s' to be '841SH', but got '%s'", `SoftBank/1.0/841SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_mobilephone_softbank(t *testing.T) {
 		if result.Name != "SoftBank Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'SoftBank Mobile', but got '%s'", `SoftBank/2.0/004SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Name)
 		}
-		if result.Os != "SoftBank" {
+		if true && result.Os != "SoftBank" {
 			t.Errorf("Expected result.Os for '%s' to be 'SoftBank', but got '%s'", `SoftBank/2.0/004SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `SoftBank/2.0/004SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.OsVersion)
 		}
-		if result.Version != "004SH" {
+		if true && result.Version != "004SH" {
 			t.Errorf("Expected result.Version for '%s' to be '004SH', but got '%s'", `SoftBank/2.0/004SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_mobilephone_softbank(t *testing.T) {
 		if result.Name != "SoftBank Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'SoftBank Mobile', but got '%s'", `SoftBank/2.0/944SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Name)
 		}
-		if result.Os != "SoftBank" {
+		if true && result.Os != "SoftBank" {
 			t.Errorf("Expected result.Os for '%s' to be 'SoftBank', but got '%s'", `SoftBank/2.0/944SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `SoftBank/2.0/944SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.OsVersion)
 		}
-		if result.Version != "944SH" {
+		if true && result.Version != "944SH" {
 			t.Errorf("Expected result.Version for '%s' to be '944SH', but got '%s'", `SoftBank/2.0/944SH/SHJ001/SN000000000000000 Browser/NetFront/3.5 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_mobilephone_softbank(t *testing.T) {
 		if result.Name != "SoftBank Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'SoftBank Mobile', but got '%s'", `SoftBank/1.0/821SC/SCJ001/SN000000000000000 Flash/Flash-Lite/2.0`, result.Name)
 		}
-		if result.Os != "SoftBank" {
+		if true && result.Os != "SoftBank" {
 			t.Errorf("Expected result.Os for '%s' to be 'SoftBank', but got '%s'", `SoftBank/1.0/821SC/SCJ001/SN000000000000000 Flash/Flash-Lite/2.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `SoftBank/1.0/821SC/SCJ001/SN000000000000000 Flash/Flash-Lite/2.0`, result.OsVersion)
 		}
-		if result.Version != "821SC" {
+		if true && result.Version != "821SC" {
 			t.Errorf("Expected result.Version for '%s' to be '821SC', but got '%s'", `SoftBank/1.0/821SC/SCJ001/SN000000000000000 Flash/Flash-Lite/2.0`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_mobilephone_softbank(t *testing.T) {
 		if result.Name != "SoftBank Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'SoftBank Mobile', but got '%s'", `Vodafone/1.0/V905SH/SHJ001 Browser/VF-NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Name)
 		}
-		if result.Os != "SoftBank" {
+		if true && result.Os != "SoftBank" {
 			t.Errorf("Expected result.Os for '%s' to be 'SoftBank', but got '%s'", `Vodafone/1.0/V905SH/SHJ001 Browser/VF-NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Vodafone/1.0/V905SH/SHJ001 Browser/VF-NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.OsVersion)
 		}
-		if result.Version != "V905SH" {
+		if true && result.Version != "V905SH" {
 			t.Errorf("Expected result.Version for '%s' to be 'V905SH', but got '%s'", `Vodafone/1.0/V905SH/SHJ001 Browser/VF-NetFront/3.3 Profile/MIDP-2.0 Configuration/CLDC-1.1`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_mobilephone_softbank(t *testing.T) {
 		if result.Name != "SoftBank Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'SoftBank Mobile', but got '%s'", `Vodafone/1.0/V804SH/SHJ001/SN0000000000000 Browser/UP.Browser/7.0.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Ext-J-Profile/JSCL-1.3.2 Ext-V-Profile/VSCL-2.0.0`, result.Name)
 		}
-		if result.Os != "SoftBank" {
+		if true && result.Os != "SoftBank" {
 			t.Errorf("Expected result.Os for '%s' to be 'SoftBank', but got '%s'", `Vodafone/1.0/V804SH/SHJ001/SN0000000000000 Browser/UP.Browser/7.0.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Ext-J-Profile/JSCL-1.3.2 Ext-V-Profile/VSCL-2.0.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Vodafone/1.0/V804SH/SHJ001/SN0000000000000 Browser/UP.Browser/7.0.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Ext-J-Profile/JSCL-1.3.2 Ext-V-Profile/VSCL-2.0.0`, result.OsVersion)
 		}
-		if result.Version != "V804SH" {
+		if true && result.Version != "V804SH" {
 			t.Errorf("Expected result.Version for '%s' to be 'V804SH', but got '%s'", `Vodafone/1.0/V804SH/SHJ001/SN0000000000000 Browser/UP.Browser/7.0.2.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Ext-J-Profile/JSCL-1.3.2 Ext-V-Profile/VSCL-2.0.0`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_mobilephone_softbank(t *testing.T) {
 		if result.Name != "SoftBank Mobile" {
 			t.Errorf("Expected result.Name for '%s' to be 'SoftBank Mobile', but got '%s'", `J-PHONE/4.0/J-T51/SNXXXXXXXXX000000000 TS/1.00 Profile/MIDP-1.0 Configuration/CLDC-1.0 Ext-Profile/JSCL-1.1.0`, result.Name)
 		}
-		if result.Os != "SoftBank" {
+		if true && result.Os != "SoftBank" {
 			t.Errorf("Expected result.Os for '%s' to be 'SoftBank', but got '%s'", `J-PHONE/4.0/J-T51/SNXXXXXXXXX000000000 TS/1.00 Profile/MIDP-1.0 Configuration/CLDC-1.0 Ext-Profile/JSCL-1.1.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `J-PHONE/4.0/J-T51/SNXXXXXXXXX000000000 TS/1.00 Profile/MIDP-1.0 Configuration/CLDC-1.0 Ext-Profile/JSCL-1.1.0`, result.OsVersion)
 		}
-		if result.Version != "J-T51" {
+		if true && result.Version != "J-T51" {
 			t.Errorf("Expected result.Version for '%s' to be 'J-T51', but got '%s'", `J-PHONE/4.0/J-T51/SNXXXXXXXXX000000000 TS/1.00 Profile/MIDP-1.0 Configuration/CLDC-1.0 Ext-Profile/JSCL-1.1.0`, result.Version)
 		}
 	}

--- a/mobilephone_willcom_test.go
+++ b/mobilephone_willcom_test.go
@@ -18,13 +18,13 @@ func Test_mobilephone_willcom(t *testing.T) {
 		if result.Name != "WILLCOM" {
 			t.Errorf("Expected result.Name for '%s' to be 'WILLCOM', but got '%s'", `Mozilla/3.0(WILLCOM;TOSHIBA/WX320T/2;1/1/C128) NetFront/3.4`, result.Name)
 		}
-		if result.Os != "WILLCOM" {
+		if true && result.Os != "WILLCOM" {
 			t.Errorf("Expected result.Os for '%s' to be 'WILLCOM', but got '%s'", `Mozilla/3.0(WILLCOM;TOSHIBA/WX320T/2;1/1/C128) NetFront/3.4`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/3.0(WILLCOM;TOSHIBA/WX320T/2;1/1/C128) NetFront/3.4`, result.OsVersion)
 		}
-		if result.Version != "WX320T" {
+		if true && result.Version != "WX320T" {
 			t.Errorf("Expected result.Version for '%s' to be 'WX320T', but got '%s'", `Mozilla/3.0(WILLCOM;TOSHIBA/WX320T/2;1/1/C128) NetFront/3.4`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_mobilephone_willcom(t *testing.T) {
 		if result.Name != "WILLCOM" {
 			t.Errorf("Expected result.Name for '%s' to be 'WILLCOM', but got '%s'", `Mozilla/3.0(WILLCOM;SANYO/WX310SA/2;1/1/C128) NetFront/3.3`, result.Name)
 		}
-		if result.Os != "WILLCOM" {
+		if true && result.Os != "WILLCOM" {
 			t.Errorf("Expected result.Os for '%s' to be 'WILLCOM', but got '%s'", `Mozilla/3.0(WILLCOM;SANYO/WX310SA/2;1/1/C128) NetFront/3.3`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/3.0(WILLCOM;SANYO/WX310SA/2;1/1/C128) NetFront/3.3`, result.OsVersion)
 		}
-		if result.Version != "WX310SA" {
+		if true && result.Version != "WX310SA" {
 			t.Errorf("Expected result.Version for '%s' to be 'WX310SA', but got '%s'", `Mozilla/3.0(WILLCOM;SANYO/WX310SA/2;1/1/C128) NetFront/3.3`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_mobilephone_willcom(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Mozilla/3.0(WILLCOM;KYOCERA/WX331K/2;1.0.8.13.000000/0.1/C100) Opera 7.2 EX`, result.Name)
 		}
-		if result.Os != "WILLCOM" {
+		if true && result.Os != "WILLCOM" {
 			t.Errorf("Expected result.Os for '%s' to be 'WILLCOM', but got '%s'", `Mozilla/3.0(WILLCOM;KYOCERA/WX331K/2;1.0.8.13.000000/0.1/C100) Opera 7.2 EX`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/3.0(WILLCOM;KYOCERA/WX331K/2;1.0.8.13.000000/0.1/C100) Opera 7.2 EX`, result.OsVersion)
 		}
-		if result.Version != "WX331K" {
+		if true && result.Version != "WX331K" {
 			t.Errorf("Expected result.Version for '%s' to be 'WX331K', but got '%s'", `Mozilla/3.0(WILLCOM;KYOCERA/WX331K/2;1.0.8.13.000000/0.1/C100) Opera 7.2 EX`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_mobilephone_willcom(t *testing.T) {
 		if result.Name != "WILLCOM" {
 			t.Errorf("Expected result.Name for '%s' to be 'WILLCOM', but got '%s'", `Mozilla/3.0(DDIPOCKET;JRC/AH-J3001V,AH-J3002V/1.0/0100/c50)CNF/2.0`, result.Name)
 		}
-		if result.Os != "WILLCOM" {
+		if true && result.Os != "WILLCOM" {
 			t.Errorf("Expected result.Os for '%s' to be 'WILLCOM', but got '%s'", `Mozilla/3.0(DDIPOCKET;JRC/AH-J3001V,AH-J3002V/1.0/0100/c50)CNF/2.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/3.0(DDIPOCKET;JRC/AH-J3001V,AH-J3002V/1.0/0100/c50)CNF/2.0`, result.OsVersion)
 		}
-		if result.Version != "AH-J3001V,AH-J3002V" {
+		if true && result.Version != "AH-J3001V,AH-J3002V" {
 			t.Errorf("Expected result.Version for '%s' to be 'AH-J3001V,AH-J3002V', but got '%s'", `Mozilla/3.0(DDIPOCKET;JRC/AH-J3001V,AH-J3002V/1.0/0100/c50)CNF/2.0`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_mobilephone_willcom(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Mozilla/3.0(DDIPOCKET;KYOCERA/AH-K3001V/1.4.1.67.000000/0.1/C100) Opera 7.0`, result.Name)
 		}
-		if result.Os != "WILLCOM" {
+		if true && result.Os != "WILLCOM" {
 			t.Errorf("Expected result.Os for '%s' to be 'WILLCOM', but got '%s'", `Mozilla/3.0(DDIPOCKET;KYOCERA/AH-K3001V/1.4.1.67.000000/0.1/C100) Opera 7.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/3.0(DDIPOCKET;KYOCERA/AH-K3001V/1.4.1.67.000000/0.1/C100) Opera 7.0`, result.OsVersion)
 		}
-		if result.Version != "AH-K3001V" {
+		if true && result.Version != "AH-K3001V" {
 			t.Errorf("Expected result.Version for '%s' to be 'AH-K3001V', but got '%s'", `Mozilla/3.0(DDIPOCKET;KYOCERA/AH-K3001V/1.4.1.67.000000/0.1/C100) Opera 7.0`, result.Version)
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -39,7 +39,7 @@ var (
 	rxPPCOsVersion           = regexp.MustCompile(`rv:(\d+\.\d+\.\d+)`)
 	rxFreeBSDOsVersion       = regexp.MustCompile(`FreeBSD ([^;\)]+);`)
 	rxChromeOSOsVersion      = regexp.MustCompile(`CrOS ([^\)]+)\)`)
-	rxAndroidOSOsVersion     = regexp.MustCompile(`Android[- ](\d+\.\d+(?:\.\d+)?)`)
+	rxAndroidOSOsVersion     = regexp.MustCompile(`Android[- ](\d+(?:\.\d+(?:\.\d+)?)?)`)
 	rxPSPOsVersion           = regexp.MustCompile(`PSP \(PlayStation Portable\); ([.0-9]+)\)`)
 	rxPS3OsVersion           = regexp.MustCompile(`PLAYSTATION 3;? ([.0-9]+)\)`)
 	rxPSVitaOsVersion        = regexp.MustCompile(`PlayStation Vita ([.0-9]+)\)`)

--- a/parser.go
+++ b/parser.go
@@ -19,7 +19,7 @@ var (
 	rxMaybeCrawlerPattern    = regexp.MustCompile(`(?i)(?:bot|crawler|spider)(?:[-_ ./;@()]|$)`)
 	rxMaybeFeedParserPattern = regexp.MustCompile(`(?i)(?:feed|web) ?parser`)
 	rxMaybeWatchdogPattern   = regexp.MustCompile(`(?i)watch ?dog`)
-	rxMSEdgePattern          = regexp.MustCompile(`Edge/([.0-9]+)`)
+	rxMSEdgePattern          = regexp.MustCompile(`(?:Edge|Edg|EdgiOS|EdgA)/([.0-9]+)`)
 	rxMSIEPattern            = regexp.MustCompile(`MSIE ([.0-9]+);`)
 	rxOperaVersionPattern1   = regexp.MustCompile(`Version/([.0-9]+)`)
 	rxOperaVersionPattern2   = regexp.MustCompile(`Opera[/ ]([.0-9]+)`)
@@ -1102,7 +1102,10 @@ func (p *Parser) ChallengeMsie(agent string, result *Result) error {
 }
 
 func (p *Parser) ChallengeMsEdge(agent string, result *Result) error {
-	if matches := rxMSEdgePattern.FindStringSubmatch(agent); matches == nil {
+	version := ValueUnknown
+	if matches := rxMSEdgePattern.FindStringSubmatch(agent); matches != nil {
+		version = matches[1]
+	} else {
 		return ErrNoMatch
 	}
 
@@ -1110,6 +1113,7 @@ func (p *Parser) ChallengeMsEdge(agent string, result *Result) error {
 	if err != nil {
 		return err
 	}
+	result.Version = version
 	return nil
 }
 

--- a/pc_lowpriority_test.go
+++ b/pc_lowpriority_test.go
@@ -18,13 +18,13 @@ func Test_pc_lowpriority(t *testing.T) {
 		if result.Name != "Sleipnir" {
 			t.Errorf("Expected result.Name for '%s' to be 'Sleipnir', but got '%s'", `Sleipnir/2.9.9`, result.Name)
 		}
-		if result.Os != "Windows UNKNOWN Ver" {
+		if true && result.Os != "Windows UNKNOWN Ver" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows UNKNOWN Ver', but got '%s'", `Sleipnir/2.9.9`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Sleipnir/2.9.9`, result.OsVersion)
 		}
-		if result.Version != "2.9.9" {
+		if true && result.Version != "2.9.9" {
 			t.Errorf("Expected result.Version for '%s' to be '2.9.9', but got '%s'", `Sleipnir/2.9.9`, result.Version)
 		}
 	}

--- a/pc_misc_test.go
+++ b/pc_misc_test.go
@@ -141,10 +141,9 @@ func Test_pc_misc(t *testing.T) {
 		if result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Instapaper/4.0 (+http://www.instapaper.com/)`, result.Os)
 		}
-		/* Skip for now
 		if result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Instapaper/4.0 (+http://www.instapaper.com/)`, result.OsVersion)
-		}*/
+		}
 		if result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Instapaper/4.0 (+http://www.instapaper.com/)`, result.Version)
 		}
@@ -342,10 +341,9 @@ func Test_pc_misc(t *testing.T) {
 		if result.Os != "BSD" {
 			t.Errorf("Expected result.Os for '%s' to be 'BSD', but got '%s'", `Mozilla/5.0 (X11; FreeBSD amd64; rv:8.0) Gecko/20100101 Firefox/8.0`, result.Os)
 		}
-		/* Skip for now
 		if result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; FreeBSD amd64; rv:8.0) Gecko/20100101 Firefox/8.0`, result.OsVersion)
-		}*/
+		}
 		if result.Version != "8.0" {
 			t.Errorf("Expected result.Version for '%s' to be '8.0', but got '%s'", `Mozilla/5.0 (X11; FreeBSD amd64; rv:8.0) Gecko/20100101 Firefox/8.0`, result.Version)
 		}
@@ -410,4 +408,5 @@ func Test_pc_misc(t *testing.T) {
 			t.Errorf("Expected result.Version for '%s' to be '17.11.1.1087', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 YaBrowser/17.11.1.1087 (beta) Yowser/2.5 Safari/537.36`, result.Version)
 		}
 	}
+
 }

--- a/pc_misc_test.go
+++ b/pc_misc_test.go
@@ -18,13 +18,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_4; ja-jp) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.2 Safari/525.20.1`, result.Name)
 		}
-		if result.Os != "Mac OSX" {
+		if true && result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_4; ja-jp) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.2 Safari/525.20.1`, result.Os)
 		}
-		if result.OsVersion != "10.5.4" {
+		if true && result.OsVersion != "10.5.4" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.5.4', but got '%s'", `Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_4; ja-jp) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.2 Safari/525.20.1`, result.OsVersion)
 		}
-		if result.Version != "3.1.2" {
+		if true && result.Version != "3.1.2" {
 			t.Errorf("Expected result.Version for '%s' to be '3.1.2', but got '%s'", `Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_4; ja-jp) AppleWebKit/525.18 (KHTML, like Gecko) Version/3.1.2 Safari/525.20.1`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Chrome" {
 			t.Errorf("Expected result.Name for '%s' to be 'Chrome', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.93 Safari/537.36`, result.Name)
 		}
-		if result.Os != "Mac OSX" {
+		if true && result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.93 Safari/537.36`, result.Os)
 		}
-		if result.OsVersion != "10.7.5" {
+		if true && result.OsVersion != "10.7.5" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.7.5', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.93 Safari/537.36`, result.OsVersion)
 		}
-		if result.Version != "27.0.1453.93" {
+		if true && result.Version != "27.0.1453.93" {
 			t.Errorf("Expected result.Version for '%s' to be '27.0.1453.93', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.93 Safari/537.36`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:21.0) Gecko/20100101 Firefox/21.0`, result.Name)
 		}
-		if result.Os != "Mac OSX" {
+		if true && result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:21.0) Gecko/20100101 Firefox/21.0`, result.Os)
 		}
-		if result.OsVersion != "10.7" {
+		if true && result.OsVersion != "10.7" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.7', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:21.0) Gecko/20100101 Firefox/21.0`, result.OsVersion)
 		}
-		if result.Version != "21.0" {
+		if true && result.Version != "21.0" {
 			t.Errorf("Expected result.Version for '%s' to be '21.0', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:21.0) Gecko/20100101 Firefox/21.0`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Opera/9.80 (Macintosh; Intel Mac OS X 10.8.3) Presto/2.12.388 Version/12.15`, result.Name)
 		}
-		if result.Os != "Mac OSX" {
+		if true && result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Opera/9.80 (Macintosh; Intel Mac OS X 10.8.3) Presto/2.12.388 Version/12.15`, result.Os)
 		}
-		if result.OsVersion != "10.8.3" {
+		if true && result.OsVersion != "10.8.3" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.8.3', but got '%s'", `Opera/9.80 (Macintosh; Intel Mac OS X 10.8.3) Presto/2.12.388 Version/12.15`, result.OsVersion)
 		}
-		if result.Version != "12.15" {
+		if true && result.Version != "12.15" {
 			t.Errorf("Expected result.Version for '%s' to be '12.15', but got '%s'", `Opera/9.80 (Macintosh; Intel Mac OS X 10.8.3) Presto/2.12.388 Version/12.15`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.154 Safari/537.36 OPR/20.0.1387.82`, result.Name)
 		}
-		if result.Os != "Mac OSX" {
+		if true && result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.154 Safari/537.36 OPR/20.0.1387.82`, result.Os)
 		}
-		if result.OsVersion != "10.9.2" {
+		if true && result.OsVersion != "10.9.2" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.9.2', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.154 Safari/537.36 OPR/20.0.1387.82`, result.OsVersion)
 		}
-		if result.Version != "20.0.1387.82" {
+		if true && result.Version != "20.0.1387.82" {
 			t.Errorf("Expected result.Version for '%s' to be '20.0.1387.82', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.154 Safari/537.36 OPR/20.0.1387.82`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Vivaldi" {
 			t.Errorf("Expected result.Name for '%s' to be 'Vivaldi', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36 Vivaldi/1.1.453.52`, result.Name)
 		}
-		if result.Os != "Mac OSX" {
+		if true && result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36 Vivaldi/1.1.453.52`, result.Os)
 		}
-		if result.OsVersion != "10.11.4" {
+		if true && result.OsVersion != "10.11.4" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.11.4', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36 Vivaldi/1.1.453.52`, result.OsVersion)
 		}
-		if result.Version != "1.1.453.52" {
+		if true && result.Version != "1.1.453.52" {
 			t.Errorf("Expected result.Version for '%s' to be '1.1.453.52', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36 Vivaldi/1.1.453.52`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Instapaper/4.0 (+http://www.instapaper.com/)`, result.Name)
 		}
-		if result.Os != "Mac OSX" {
+		if true && result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Instapaper/4.0 (+http://www.instapaper.com/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Instapaper/4.0 (+http://www.instapaper.com/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.50 (KHTML, like Gecko) Version/5.1 Instapaper/4.0 (+http://www.instapaper.com/)`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.5; ja-JP-mac; rv:1.9.1.19) Gecko/20110420 SeaMonkey/2.0.14`, result.Name)
 		}
-		if result.Os != "Mac OSX" {
+		if true && result.Os != "Mac OSX" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OSX', but got '%s'", `Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.5; ja-JP-mac; rv:1.9.1.19) Gecko/20110420 SeaMonkey/2.0.14`, result.Os)
 		}
-		if result.OsVersion != "10.5" {
+		if true && result.OsVersion != "10.5" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.5', but got '%s'", `Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.5; ja-JP-mac; rv:1.9.1.19) Gecko/20110420 SeaMonkey/2.0.14`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.5; ja-JP-mac; rv:1.9.1.19) Gecko/20110420 SeaMonkey/2.0.14`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (Macintosh; U; PPC; en-US; mimic; rv:9.2.1) (mimic Gecko/20100722 Firefox/3.6.8) Classilla/CFM`, result.Name)
 		}
-		if result.Os != "Mac OS Classic" {
+		if true && result.Os != "Mac OS Classic" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OS Classic', but got '%s'", `Mozilla/5.0 (Macintosh; U; PPC; en-US; mimic; rv:9.2.1) (mimic Gecko/20100722 Firefox/3.6.8) Classilla/CFM`, result.Os)
 		}
-		if result.OsVersion != "9.2.1" {
+		if true && result.OsVersion != "9.2.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '9.2.1', but got '%s'", `Mozilla/5.0 (Macintosh; U; PPC; en-US; mimic; rv:9.2.1) (mimic Gecko/20100722 Firefox/3.6.8) Classilla/CFM`, result.OsVersion)
 		}
-		if result.Version != "3.6.8" {
+		if true && result.Version != "3.6.8" {
 			t.Errorf("Expected result.Version for '%s' to be '3.6.8', but got '%s'", `Mozilla/5.0 (Macintosh; U; PPC; en-US; mimic; rv:9.2.1) (mimic Gecko/20100722 Firefox/3.6.8) Classilla/CFM`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 5.17; Mac_PowerPC)`, result.Name)
 		}
-		if result.Os != "Mac OS Classic" {
+		if true && result.Os != "Mac OS Classic" {
 			t.Errorf("Expected result.Os for '%s' to be 'Mac OS Classic', but got '%s'", `Mozilla/4.0 (compatible; MSIE 5.17; Mac_PowerPC)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.0 (compatible; MSIE 5.17; Mac_PowerPC)`, result.OsVersion)
 		}
-		if result.Version != "5.17" {
+		if true && result.Version != "5.17" {
 			t.Errorf("Expected result.Version for '%s' to be '5.17', but got '%s'", `Mozilla/4.0 (compatible; MSIE 5.17; Mac_PowerPC)`, result.Version)
 		}
 	}
@@ -218,13 +218,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (Ubuntu; X11; Linux i686; rv:9.0.1) Gecko/20100101 Firefox/9.0.1`, result.Name)
 		}
-		if result.Os != "Linux" {
+		if true && result.Os != "Linux" {
 			t.Errorf("Expected result.Os for '%s' to be 'Linux', but got '%s'", `Mozilla/5.0 (Ubuntu; X11; Linux i686; rv:9.0.1) Gecko/20100101 Firefox/9.0.1`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Ubuntu; X11; Linux i686; rv:9.0.1) Gecko/20100101 Firefox/9.0.1`, result.OsVersion)
 		}
-		if result.Version != "9.0.1" {
+		if true && result.Version != "9.0.1" {
 			t.Errorf("Expected result.Version for '%s' to be '9.0.1', but got '%s'", `Mozilla/5.0 (Ubuntu; X11; Linux i686; rv:9.0.1) Gecko/20100101 Firefox/9.0.1`, result.Version)
 		}
 	}
@@ -238,13 +238,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Chrome" {
 			t.Errorf("Expected result.Name for '%s' to be 'Chrome', but got '%s'", `Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7`, result.Name)
 		}
-		if result.Os != "Linux" {
+		if true && result.Os != "Linux" {
 			t.Errorf("Expected result.Os for '%s' to be 'Linux', but got '%s'", `Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7`, result.OsVersion)
 		}
-		if result.Version != "16.0.912.75" {
+		if true && result.Version != "16.0.912.75" {
 			t.Errorf("Expected result.Version for '%s' to be '16.0.912.75', but got '%s'", `Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7`, result.Version)
 		}
 	}
@@ -258,13 +258,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Vivaldi" {
 			t.Errorf("Expected result.Name for '%s' to be 'Vivaldi', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.99 Safari/537.36 Vivaldi/1.0.321.3`, result.Name)
 		}
-		if result.Os != "Linux" {
+		if true && result.Os != "Linux" {
 			t.Errorf("Expected result.Os for '%s' to be 'Linux', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.99 Safari/537.36 Vivaldi/1.0.321.3`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.99 Safari/537.36 Vivaldi/1.0.321.3`, result.OsVersion)
 		}
-		if result.Version != "1.0.321.3" {
+		if true && result.Version != "1.0.321.3" {
 			t.Errorf("Expected result.Version for '%s' to be '1.0.321.3', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.99 Safari/537.36 Vivaldi/1.0.321.3`, result.Version)
 		}
 	}
@@ -278,13 +278,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.2.24) Gecko cXense`, result.Name)
 		}
-		if result.Os != "Linux" {
+		if true && result.Os != "Linux" {
 			t.Errorf("Expected result.Os for '%s' to be 'Linux', but got '%s'", `Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.2.24) Gecko cXense`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.2.24) Gecko cXense`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.2.24) Gecko cXense`, result.Version)
 		}
 	}
@@ -298,13 +298,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux i686; ja-JP; rv:1.8.1.23) Gecko/20090910 SeaMonkey/1.1.18`, result.Name)
 		}
-		if result.Os != "Linux" {
+		if true && result.Os != "Linux" {
 			t.Errorf("Expected result.Os for '%s' to be 'Linux', but got '%s'", `Mozilla/5.0 (X11; U; Linux i686; ja-JP; rv:1.8.1.23) Gecko/20090910 SeaMonkey/1.1.18`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux i686; ja-JP; rv:1.8.1.23) Gecko/20090910 SeaMonkey/1.1.18`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux i686; ja-JP; rv:1.8.1.23) Gecko/20090910 SeaMonkey/1.1.18`, result.Version)
 		}
 	}
@@ -318,13 +318,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.0.3) Gecko/2008092814 Iceweasel/3.0.3 (Debian-3.0.3-3)`, result.Name)
 		}
-		if result.Os != "Linux" {
+		if true && result.Os != "Linux" {
 			t.Errorf("Expected result.Os for '%s' to be 'Linux', but got '%s'", `Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.0.3) Gecko/2008092814 Iceweasel/3.0.3 (Debian-3.0.3-3)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.0.3) Gecko/2008092814 Iceweasel/3.0.3 (Debian-3.0.3-3)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.0.3) Gecko/2008092814 Iceweasel/3.0.3 (Debian-3.0.3-3)`, result.Version)
 		}
 	}
@@ -338,13 +338,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (X11; FreeBSD amd64; rv:8.0) Gecko/20100101 Firefox/8.0`, result.Name)
 		}
-		if result.Os != "BSD" {
+		if true && result.Os != "BSD" {
 			t.Errorf("Expected result.Os for '%s' to be 'BSD', but got '%s'", `Mozilla/5.0 (X11; FreeBSD amd64; rv:8.0) Gecko/20100101 Firefox/8.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; FreeBSD amd64; rv:8.0) Gecko/20100101 Firefox/8.0`, result.OsVersion)
 		}
-		if result.Version != "8.0" {
+		if true && result.Version != "8.0" {
 			t.Errorf("Expected result.Version for '%s' to be '8.0', but got '%s'", `Mozilla/5.0 (X11; FreeBSD amd64; rv:8.0) Gecko/20100101 Firefox/8.0`, result.Version)
 		}
 	}
@@ -358,13 +358,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Opera/9.80 (X11; FreeBSD 8.2-RELEASE-p3 amd64; U; ja) Presto/2.9.168 Version/11.52`, result.Name)
 		}
-		if result.Os != "BSD" {
+		if true && result.Os != "BSD" {
 			t.Errorf("Expected result.Os for '%s' to be 'BSD', but got '%s'", `Opera/9.80 (X11; FreeBSD 8.2-RELEASE-p3 amd64; U; ja) Presto/2.9.168 Version/11.52`, result.Os)
 		}
-		if result.OsVersion != "8.2-RELEASE-p3 amd64" {
+		if true && result.OsVersion != "8.2-RELEASE-p3 amd64" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '8.2-RELEASE-p3 amd64', but got '%s'", `Opera/9.80 (X11; FreeBSD 8.2-RELEASE-p3 amd64; U; ja) Presto/2.9.168 Version/11.52`, result.OsVersion)
 		}
-		if result.Version != "11.52" {
+		if true && result.Version != "11.52" {
 			t.Errorf("Expected result.Version for '%s' to be '11.52', but got '%s'", `Opera/9.80 (X11; FreeBSD 8.2-RELEASE-p3 amd64; U; ja) Presto/2.9.168 Version/11.52`, result.Version)
 		}
 	}
@@ -378,13 +378,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Chrome" {
 			t.Errorf("Expected result.Name for '%s' to be 'Chrome', but got '%s'", `Mozilla/5.0 (X11; CrOS x86_64 5116.115.4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36`, result.Name)
 		}
-		if result.Os != "ChromeOS" {
+		if true && result.Os != "ChromeOS" {
 			t.Errorf("Expected result.Os for '%s' to be 'ChromeOS', but got '%s'", `Mozilla/5.0 (X11; CrOS x86_64 5116.115.4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36`, result.Os)
 		}
-		if result.OsVersion != "x86_64 5116.115.4" {
+		if true && result.OsVersion != "x86_64 5116.115.4" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'x86_64 5116.115.4', but got '%s'", `Mozilla/5.0 (X11; CrOS x86_64 5116.115.4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36`, result.OsVersion)
 		}
-		if result.Version != "33.0.1750.152" {
+		if true && result.Version != "33.0.1750.152" {
 			t.Errorf("Expected result.Version for '%s' to be '33.0.1750.152', but got '%s'", `Mozilla/5.0 (X11; CrOS x86_64 5116.115.4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.152 Safari/537.36`, result.Version)
 		}
 	}
@@ -398,13 +398,13 @@ func Test_pc_misc(t *testing.T) {
 		if result.Name != "Yandex Browser" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yandex Browser', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 YaBrowser/17.11.1.1087 (beta) Yowser/2.5 Safari/537.36`, result.Name)
 		}
-		if result.Os != "Linux" {
+		if true && result.Os != "Linux" {
 			t.Errorf("Expected result.Os for '%s' to be 'Linux', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 YaBrowser/17.11.1.1087 (beta) Yowser/2.5 Safari/537.36`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 YaBrowser/17.11.1.1087 (beta) Yowser/2.5 Safari/537.36`, result.OsVersion)
 		}
-		if result.Version != "17.11.1.1087" {
+		if true && result.Version != "17.11.1.1087" {
 			t.Errorf("Expected result.Version for '%s' to be '17.11.1.1087', but got '%s'", `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 YaBrowser/17.11.1.1087 (beta) Yowser/2.5 Safari/537.36`, result.Version)
 		}
 	}

--- a/pc_win_test.go
+++ b/pc_win_test.go
@@ -348,6 +348,26 @@ func Test_pc_win(t *testing.T) {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240`, result.Version)
 		}
 	}
+	result, err = Parse(`Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`)
+	if err != nil {
+		t.Errorf(`Failed to parse 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24': %s`, err)
+	} else {
+		if result.Category != "pc" {
+			t.Errorf("Expected result.Category for '%s' to be 'pc', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.Category)
+		}
+		if result.Name != "Edge" {
+			t.Errorf("Expected result.Name for '%s' to be 'Edge', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.Name)
+		}
+		if result.Os != "Windows 10" {
+			t.Errorf("Expected result.Os for '%s' to be 'Windows 10', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.Os)
+		}
+		if result.OsVersion != "NT 10.0" {
+			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 10.0', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.OsVersion)
+		}
+		if result.Version != "UNKNOWN" {
+			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.Version)
+		}
+	}
 	result, err = Parse(`Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.2.149.27 Safari/525.13`)
 	if err != nil {
 		t.Errorf(`Failed to parse 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.2.149.27 Safari/525.13': %s`, err)

--- a/pc_win_test.go
+++ b/pc_win_test.go
@@ -18,13 +18,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)`, result.Name)
 		}
-		if result.Os != "Windows 2000" {
+		if true && result.Os != "Windows 2000" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 2000', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)`, result.Os)
 		}
-		if result.OsVersion != "NT 5.0" {
+		if true && result.OsVersion != "NT 5.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)`, result.OsVersion)
 		}
-		if result.Version != "6.0" {
+		if true && result.Version != "6.0" {
 			t.Errorf("Expected result.Version for '%s' to be '6.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; InfoPath.1)`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)`, result.Name)
 		}
-		if result.Os != "Windows XP" {
+		if true && result.Os != "Windows XP" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows XP', but got '%s'", `Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)`, result.Os)
 		}
-		if result.OsVersion != "NT 5.1" {
+		if true && result.OsVersion != "NT 5.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.1', but got '%s'", `Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)`, result.OsVersion)
 		}
-		if result.Version != "7.0" {
+		if true && result.Version != "7.0" {
 			t.Errorf("Expected result.Version for '%s' to be '7.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322)`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; 2004/11/08; GoogleT5; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)`, result.Name)
 		}
-		if result.Os != "Windows XP" {
+		if true && result.Os != "Windows XP" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows XP', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; 2004/11/08; GoogleT5; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)`, result.Os)
 		}
-		if result.OsVersion != "NT 5.1" {
+		if true && result.OsVersion != "NT 5.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.1', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; 2004/11/08; GoogleT5; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)`, result.OsVersion)
 		}
-		if result.Version != "8.0" {
+		if true && result.Version != "8.0" {
 			t.Errorf("Expected result.Version for '%s' to be '8.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; 2004/11/08; GoogleT5; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; BOIE8;ENUSMSCOM)`, result.Name)
 		}
-		if result.Os != "Windows XP" {
+		if true && result.Os != "Windows XP" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows XP', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; BOIE8;ENUSMSCOM)`, result.Os)
 		}
-		if result.OsVersion != "NT 5.1" {
+		if true && result.OsVersion != "NT 5.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.1', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; BOIE8;ENUSMSCOM)`, result.OsVersion)
 		}
-		if result.Version != "8.0" {
+		if true && result.Version != "8.0" {
 			t.Errorf("Expected result.Version for '%s' to be '8.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET4.0C; BOIE8;ENUSMSCOM)`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)`, result.Name)
 		}
-		if result.Os != "Windows Vista" {
+		if true && result.Os != "Windows Vista" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows Vista', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)`, result.Os)
 		}
-		if result.OsVersion != "NT 6.0" {
+		if true && result.OsVersion != "NT 6.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)`, result.OsVersion)
 		}
-		if result.Version != "8.0" {
+		if true && result.Version != "8.0" {
 			t.Errorf("Expected result.Version for '%s' to be '8.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)`, result.Name)
 		}
-		if result.Os != "Windows 7" {
+		if true && result.Os != "Windows 7" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 7', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)`, result.Os)
 		}
-		if result.OsVersion != "NT 6.1" {
+		if true && result.OsVersion != "NT 6.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.1', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)`, result.OsVersion)
 		}
-		if result.Version != "8.0" {
+		if true && result.Version != "8.0" {
 			t.Errorf("Expected result.Version for '%s' to be '8.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)`, result.Name)
 		}
-		if result.Os != "Windows 7" {
+		if true && result.Os != "Windows 7" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 7', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)`, result.Os)
 		}
-		if result.OsVersion != "NT 6.1" {
+		if true && result.OsVersion != "NT 6.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.1', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)`, result.OsVersion)
 		}
-		if result.Version != "9.0" {
+		if true && result.Version != "9.0" {
 			t.Errorf("Expected result.Version for '%s' to be '9.0', but got '%s'", `Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0)`, result.Name)
 		}
-		if result.Os != "Windows 8" {
+		if true && result.Os != "Windows 8" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 8', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0)`, result.Os)
 		}
-		if result.OsVersion != "NT 6.2" {
+		if true && result.OsVersion != "NT 6.2" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.2', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0)`, result.OsVersion)
 		}
-		if result.Version != "10.0" {
+		if true && result.Version != "10.0" {
 			t.Errorf("Expected result.Version for '%s' to be '10.0', but got '%s'", `Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0)`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Trident/7.0; BOIE9;JAJP; rv:11.0) like Gecko`, result.Name)
 		}
-		if result.Os != "Windows 7" {
+		if true && result.Os != "Windows 7" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 7', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Trident/7.0; BOIE9;JAJP; rv:11.0) like Gecko`, result.Os)
 		}
-		if result.OsVersion != "NT 6.1" {
+		if true && result.OsVersion != "NT 6.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Trident/7.0; BOIE9;JAJP; rv:11.0) like Gecko`, result.OsVersion)
 		}
-		if result.Version != "11.0" {
+		if true && result.Version != "11.0" {
 			t.Errorf("Expected result.Version for '%s' to be '11.0', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Trident/7.0; BOIE9;JAJP; rv:11.0) like Gecko`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko`, result.Name)
 		}
-		if result.Os != "Windows 8.1" {
+		if true && result.Os != "Windows 8.1" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 8.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko`, result.Os)
 		}
-		if result.OsVersion != "NT 6.3" {
+		if true && result.OsVersion != "NT 6.3" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.3', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko`, result.OsVersion)
 		}
-		if result.Version != "11.0" {
+		if true && result.Version != "11.0" {
 			t.Errorf("Expected result.Version for '%s' to be '11.0', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko`, result.Version)
 		}
 	}
@@ -218,13 +218,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Trident/7.0; MALCJS; rv:11.0) like Gecko`, result.Name)
 		}
-		if result.Os != "Windows 7" {
+		if true && result.Os != "Windows 7" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 7', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Trident/7.0; MALCJS; rv:11.0) like Gecko`, result.Os)
 		}
-		if result.OsVersion != "NT 6.1" {
+		if true && result.OsVersion != "NT 6.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Trident/7.0; MALCJS; rv:11.0) like Gecko`, result.OsVersion)
 		}
-		if result.Version != "11.0" {
+		if true && result.Version != "11.0" {
 			t.Errorf("Expected result.Version for '%s' to be '11.0', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Trident/7.0; MALCJS; rv:11.0) like Gecko`, result.Version)
 		}
 	}
@@ -238,13 +238,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Win64; x64; Trident/7.0; MASPJS; rv:11.0) like Gecko`, result.Name)
 		}
-		if result.Os != "Windows 7" {
+		if true && result.Os != "Windows 7" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 7', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Win64; x64; Trident/7.0; MASPJS; rv:11.0) like Gecko`, result.Os)
 		}
-		if result.OsVersion != "NT 6.1" {
+		if true && result.OsVersion != "NT 6.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Win64; x64; Trident/7.0; MASPJS; rv:11.0) like Gecko`, result.OsVersion)
 		}
-		if result.Version != "11.0" {
+		if true && result.Version != "11.0" {
 			t.Errorf("Expected result.Version for '%s' to be '11.0', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; Win64; x64; Trident/7.0; MASPJS; rv:11.0) like Gecko`, result.Version)
 		}
 	}
@@ -258,13 +258,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko`, result.Name)
 		}
-		if result.Os != "Windows 8.1" {
+		if true && result.Os != "Windows 8.1" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 8.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko`, result.Os)
 		}
-		if result.OsVersion != "NT 6.3" {
+		if true && result.OsVersion != "NT 6.3" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.3', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko`, result.OsVersion)
 		}
-		if result.Version != "11.0" {
+		if true && result.Version != "11.0" {
 			t.Errorf("Expected result.Version for '%s' to be '11.0', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko`, result.Version)
 		}
 	}
@@ -278,13 +278,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; Touch; rv:11.0) like Gecko`, result.Name)
 		}
-		if result.Os != "Windows 8.1" {
+		if true && result.Os != "Windows 8.1" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 8.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; Touch; rv:11.0) like Gecko`, result.Os)
 		}
-		if result.OsVersion != "NT 6.3" {
+		if true && result.OsVersion != "NT 6.3" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.3', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; Touch; rv:11.0) like Gecko`, result.OsVersion)
 		}
-		if result.Version != "11.0" {
+		if true && result.Version != "11.0" {
 			t.Errorf("Expected result.Version for '%s' to be '11.0', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; Touch; rv:11.0) like Gecko`, result.Version)
 		}
 	}
@@ -298,13 +298,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.78 [ja] (Win98; U)`, result.Name)
 		}
-		if result.Os != "Windows 98" {
+		if true && result.Os != "Windows 98" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 98', but got '%s'", `Mozilla/4.78 [ja] (Win98; U)`, result.Os)
 		}
-		if result.OsVersion != "98" {
+		if true && result.OsVersion != "98" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '98', but got '%s'", `Mozilla/4.78 [ja] (Win98; U)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.78 [ja] (Win98; U)`, result.Version)
 		}
 	}
@@ -318,13 +318,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko)`, result.Name)
 		}
-		if result.Os != "Windows 7" {
+		if true && result.Os != "Windows 7" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 7', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko)`, result.Os)
 		}
-		if result.OsVersion != "NT 6.1" {
+		if true && result.OsVersion != "NT 6.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko)`, result.Version)
 		}
 	}
@@ -338,13 +338,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Edge" {
 			t.Errorf("Expected result.Name for '%s' to be 'Edge', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240`, result.Name)
 		}
-		if result.Os != "Windows 10" {
+		if true && result.Os != "Windows 10" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 10', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240`, result.Os)
 		}
-		if result.OsVersion != "NT 10.0" {
+		if true && result.OsVersion != "NT 10.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 10.0', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240`, result.Version)
 		}
 	}
@@ -358,13 +358,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Edge" {
 			t.Errorf("Expected result.Name for '%s' to be 'Edge', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.Name)
 		}
-		if result.Os != "Windows 10" {
+		if true && result.Os != "Windows 10" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 10', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.Os)
 		}
-		if result.OsVersion != "NT 10.0" {
+		if true && result.OsVersion != "NT 10.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 10.0', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.48 Safari/537.36 Edg/74.1.96.24`, result.Version)
 		}
 	}
@@ -378,13 +378,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Chrome" {
 			t.Errorf("Expected result.Name for '%s' to be 'Chrome', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.2.149.27 Safari/525.13`, result.Name)
 		}
-		if result.Os != "Windows XP" {
+		if true && result.Os != "Windows XP" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows XP', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.2.149.27 Safari/525.13`, result.Os)
 		}
-		if result.OsVersion != "NT 5.1" {
+		if true && result.OsVersion != "NT 5.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.1', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.2.149.27 Safari/525.13`, result.OsVersion)
 		}
-		if result.Version != "0.2.149.27" {
+		if true && result.Version != "0.2.149.27" {
 			t.Errorf("Expected result.Version for '%s' to be '0.2.149.27', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US) AppleWebKit/525.13 (KHTML, like Gecko) Chrome/0.2.149.27 Safari/525.13`, result.Version)
 		}
 	}
@@ -398,13 +398,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (Windows NT 6.0; rv:9.0.1) Gecko/20100101 Firefox/9.0.1`, result.Name)
 		}
-		if result.Os != "Windows Vista" {
+		if true && result.Os != "Windows Vista" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows Vista', but got '%s'", `Mozilla/5.0 (Windows NT 6.0; rv:9.0.1) Gecko/20100101 Firefox/9.0.1`, result.Os)
 		}
-		if result.OsVersion != "NT 6.0" {
+		if true && result.OsVersion != "NT 6.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.0', but got '%s'", `Mozilla/5.0 (Windows NT 6.0; rv:9.0.1) Gecko/20100101 Firefox/9.0.1`, result.OsVersion)
 		}
-		if result.Version != "9.0.1" {
+		if true && result.Version != "9.0.1" {
 			t.Errorf("Expected result.Version for '%s' to be '9.0.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.0; rv:9.0.1) Gecko/20100101 Firefox/9.0.1`, result.Version)
 		}
 	}
@@ -418,13 +418,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (Windows NT 5.1) AppleWebKit/534.52.7 (KHTML, like Gecko) Version/5.1.2 Safari/534.52.7`, result.Name)
 		}
-		if result.Os != "Windows XP" {
+		if true && result.Os != "Windows XP" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows XP', but got '%s'", `Mozilla/5.0 (Windows NT 5.1) AppleWebKit/534.52.7 (KHTML, like Gecko) Version/5.1.2 Safari/534.52.7`, result.Os)
 		}
-		if result.OsVersion != "NT 5.1" {
+		if true && result.OsVersion != "NT 5.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.1', but got '%s'", `Mozilla/5.0 (Windows NT 5.1) AppleWebKit/534.52.7 (KHTML, like Gecko) Version/5.1.2 Safari/534.52.7`, result.OsVersion)
 		}
-		if result.Version != "5.1.2" {
+		if true && result.Version != "5.1.2" {
 			t.Errorf("Expected result.Version for '%s' to be '5.1.2', but got '%s'", `Mozilla/5.0 (Windows NT 5.1) AppleWebKit/534.52.7 (KHTML, like Gecko) Version/5.1.2 Safari/534.52.7`, result.Version)
 		}
 	}
@@ -438,13 +438,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Opera/9.52 (Windows NT 5.1; U; ja)`, result.Name)
 		}
-		if result.Os != "Windows XP" {
+		if true && result.Os != "Windows XP" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows XP', but got '%s'", `Opera/9.52 (Windows NT 5.1; U; ja)`, result.Os)
 		}
-		if result.OsVersion != "NT 5.1" {
+		if true && result.OsVersion != "NT 5.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.1', but got '%s'", `Opera/9.52 (Windows NT 5.1; U; ja)`, result.OsVersion)
 		}
-		if result.Version != "9.52" {
+		if true && result.Version != "9.52" {
 			t.Errorf("Expected result.Version for '%s' to be '9.52', but got '%s'", `Opera/9.52 (Windows NT 5.1; U; ja)`, result.Version)
 		}
 	}
@@ -458,13 +458,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Vivaldi" {
 			t.Errorf("Expected result.Name for '%s' to be 'Vivaldi', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.88 Safari/537.36 Vivaldi/1.0.380.2`, result.Name)
 		}
-		if result.Os != "Windows 10" {
+		if true && result.Os != "Windows 10" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 10', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.88 Safari/537.36 Vivaldi/1.0.380.2`, result.Os)
 		}
-		if result.OsVersion != "NT 10.0" {
+		if true && result.OsVersion != "NT 10.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 10.0', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.88 Safari/537.36 Vivaldi/1.0.380.2`, result.OsVersion)
 		}
-		if result.Version != "1.0.380.2" {
+		if true && result.Version != "1.0.380.2" {
 			t.Errorf("Expected result.Version for '%s' to be '1.0.380.2', but got '%s'", `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.88 Safari/537.36 Vivaldi/1.0.380.2`, result.Version)
 		}
 	}
@@ -478,13 +478,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.117 Safari/537.36 OPR/20.0.1387.64`, result.Name)
 		}
-		if result.Os != "Windows 8.1" {
+		if true && result.Os != "Windows 8.1" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 8.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.117 Safari/537.36 OPR/20.0.1387.64`, result.Os)
 		}
-		if result.OsVersion != "NT 6.3" {
+		if true && result.OsVersion != "NT 6.3" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.3', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.117 Safari/537.36 OPR/20.0.1387.64`, result.OsVersion)
 		}
-		if result.Version != "20.0.1387.64" {
+		if true && result.Version != "20.0.1387.64" {
 			t.Errorf("Expected result.Version for '%s' to be '20.0.1387.64', but got '%s'", `Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.117 Safari/537.36 OPR/20.0.1387.64`, result.Version)
 		}
 	}
@@ -498,13 +498,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1) Sleipnir/2.8.0`, result.Name)
 		}
-		if result.Os != "Windows XP" {
+		if true && result.Os != "Windows XP" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows XP', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1) Sleipnir/2.8.0`, result.Os)
 		}
-		if result.OsVersion != "NT 5.1" {
+		if true && result.OsVersion != "NT 5.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.1', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1) Sleipnir/2.8.0`, result.OsVersion)
 		}
-		if result.Version != "6.0" {
+		if true && result.Version != "6.0" {
 			t.Errorf("Expected result.Version for '%s' to be '6.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1) Sleipnir/2.8.0`, result.Version)
 		}
 	}
@@ -518,13 +518,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; ja-JP; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)`, result.Name)
 		}
-		if result.Os != "Windows Vista" {
+		if true && result.Os != "Windows Vista" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows Vista', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; ja-JP; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)`, result.Os)
 		}
-		if result.OsVersion != "NT 6.0" {
+		if true && result.OsVersion != "NT 6.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.0', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; ja-JP; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows; U; Windows NT 6.0; ja-JP; rv:1.4) Gecko/20030624 Netscape/7.1 (ax)`, result.Version)
 		}
 	}
@@ -538,13 +538,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 5.1; rv:8.0) Gecko/20111105 Thunderbird/8.0`, result.Name)
 		}
-		if result.Os != "Windows XP" {
+		if true && result.Os != "Windows XP" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows XP', but got '%s'", `Mozilla/5.0 (Windows NT 5.1; rv:8.0) Gecko/20111105 Thunderbird/8.0`, result.Os)
 		}
-		if result.OsVersion != "NT 5.1" {
+		if true && result.OsVersion != "NT 5.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 5.1', but got '%s'", `Mozilla/5.0 (Windows NT 5.1; rv:8.0) Gecko/20111105 Thunderbird/8.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Windows NT 5.1; rv:8.0) Gecko/20111105 Thunderbird/8.0`, result.Version)
 		}
 	}
@@ -558,13 +558,13 @@ func Test_pc_win(t *testing.T) {
 		if result.Name != "Yandex Browser" {
 			t.Errorf("Expected result.Name for '%s' to be 'Yandex Browser', but got '%s'", `Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 YaBrowser/18.1.1.839 Yowser/2.5 Safari/537.36`, result.Name)
 		}
-		if result.Os != "Windows 7" {
+		if true && result.Os != "Windows 7" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows 7', but got '%s'", `Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 YaBrowser/18.1.1.839 Yowser/2.5 Safari/537.36`, result.Os)
 		}
-		if result.OsVersion != "NT 6.1" {
+		if true && result.OsVersion != "NT 6.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'NT 6.1', but got '%s'", `Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 YaBrowser/18.1.1.839 Yowser/2.5 Safari/537.36`, result.OsVersion)
 		}
-		if result.Version != "18.1.1.839" {
+		if true && result.Version != "18.1.1.839" {
 			t.Errorf("Expected result.Version for '%s' to be '18.1.1.839', but got '%s'", `Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 YaBrowser/18.1.1.839 Yowser/2.5 Safari/537.36`, result.Version)
 		}
 	}

--- a/smartphone_android__test.go
+++ b/smartphone_android__test.go
@@ -18,13 +18,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; ISW11F Build/FGK500) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; ISW11F Build/FGK500) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1`, result.Os)
 		}
-		if result.OsVersion != "2.3.5" {
+		if true && result.OsVersion != "2.3.5" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '2.3.5', but got '%s'", `Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; ISW11F Build/FGK500) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1`, result.OsVersion)
 		}
-		if result.Version != "4.0" {
+		if true && result.Version != "4.0" {
 			t.Errorf("Expected result.Version for '%s' to be '4.0', but got '%s'", `Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; ISW11F Build/FGK500) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (Linux; U; Android 3.1; ja-jp; L-06C Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; U; Android 3.1; ja-jp; L-06C Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13`, result.Os)
 		}
-		if result.OsVersion != "3.1" {
+		if true && result.OsVersion != "3.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '3.1', but got '%s'", `Mozilla/5.0 (Linux; U; Android 3.1; ja-jp; L-06C Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13`, result.OsVersion)
 		}
-		if result.Version != "4.0" {
+		if true && result.Version != "4.0" {
 			t.Errorf("Expected result.Version for '%s' to be '4.0', but got '%s'", `Mozilla/5.0 (Linux; U; Android 3.1; ja-jp; L-06C Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Chrome" {
 			t.Errorf("Expected result.Name for '%s' to be 'Chrome', but got '%s'", `Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7`, result.Os)
 		}
-		if result.OsVersion != "4.0.3" {
+		if true && result.OsVersion != "4.0.3" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '4.0.3', but got '%s'", `Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7`, result.OsVersion)
 		}
-		if result.Version != "16.0.912.75" {
+		if true && result.Version != "16.0.912.75" {
 			t.Errorf("Expected result.Version for '%s' to be '16.0.912.75', but got '%s'", `Mozilla/5.0 (Linux; U; Android-4.0.3; en-us; Galaxy Nexus Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Opera/9.80 (Android; Opera Mini/6.5.27452/26.1305; U; ja) Presto/2.8.119 Version/10.54`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Opera/9.80 (Android; Opera Mini/6.5.27452/26.1305; U; ja) Presto/2.8.119 Version/10.54`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Opera/9.80 (Android; Opera Mini/6.5.27452/26.1305; U; ja) Presto/2.8.119 Version/10.54`, result.OsVersion)
 		}
-		if result.Version != "10.54" {
+		if true && result.Version != "10.54" {
 			t.Errorf("Expected result.Version for '%s' to be '10.54', but got '%s'", `Opera/9.80 (Android; Opera Mini/6.5.27452/26.1305; U; ja) Presto/2.8.119 Version/10.54`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Mozilla/5.0 (Linux; Android 4.2.2; SO-01F Build/14.1.H.1.281) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36 OPR/20.0.1396.73172`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; Android 4.2.2; SO-01F Build/14.1.H.1.281) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36 OPR/20.0.1396.73172`, result.Os)
 		}
-		if result.OsVersion != "4.2.2" {
+		if true && result.OsVersion != "4.2.2" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '4.2.2', but got '%s'", `Mozilla/5.0 (Linux; Android 4.2.2; SO-01F Build/14.1.H.1.281) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36 OPR/20.0.1396.73172`, result.OsVersion)
 		}
-		if result.Version != "20.0.1396.73172" {
+		if true && result.Version != "20.0.1396.73172" {
 			t.Errorf("Expected result.Version for '%s' to be '20.0.1396.73172', but got '%s'", `Mozilla/5.0 (Linux; Android 4.2.2; SO-01F Build/14.1.H.1.281) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36 OPR/20.0.1396.73172`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (Android; Mobile; rv:14.0) Gecko/14.0 Firefox/14.0`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Android; Mobile; rv:14.0) Gecko/14.0 Firefox/14.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Android; Mobile; rv:14.0) Gecko/14.0 Firefox/14.0`, result.OsVersion)
 		}
-		if result.Version != "14.0" {
+		if true && result.Version != "14.0" {
 			t.Errorf("Expected result.Version for '%s' to be '14.0', but got '%s'", `Mozilla/5.0 (Android; Mobile; rv:14.0) Gecko/14.0 Firefox/14.0`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (Android; Tablet; rv:14.0) Gecko/14.0 Firefox/14.0`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Android; Tablet; rv:14.0) Gecko/14.0 Firefox/14.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Android; Tablet; rv:14.0) Gecko/14.0 Firefox/14.0`, result.OsVersion)
 		}
-		if result.Version != "14.0" {
+		if true && result.Version != "14.0" {
 			t.Errorf("Expected result.Version for '%s' to be '14.0', but got '%s'", `Mozilla/5.0 (Android; Tablet; rv:14.0) Gecko/14.0 Firefox/14.0`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Edge" {
 			t.Errorf("Expected result.Name for '%s' to be 'Edge', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.Os)
 		}
-		if result.OsVersion != "8.0" {
+		if true && result.OsVersion != "8.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '8.0', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.OsVersion)
 		}
-		if result.Version != "41.1.35.1" {
+		if true && result.Version != "41.1.35.1" {
 			t.Errorf("Expected result.Version for '%s' to be '41.1.35.1', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Dalvik/1.4.0 (Linux; U; Android 2.3.4; SBM009SH Build/S0008)`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Dalvik/1.4.0 (Linux; U; Android 2.3.4; SBM009SH Build/S0008)`, result.Os)
 		}
-		if result.OsVersion != "2.3.4" {
+		if true && result.OsVersion != "2.3.4" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '2.3.4', but got '%s'", `Dalvik/1.4.0 (Linux; U; Android 2.3.4; SBM009SH Build/S0008)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Dalvik/1.4.0 (Linux; U; Android 2.3.4; SBM009SH Build/S0008)`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `LDNReader/2.0.1 (Android)`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `LDNReader/2.0.1 (Android)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `LDNReader/2.0.1 (Android)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `LDNReader/2.0.1 (Android)`, result.Version)
 		}
 	}
@@ -218,13 +218,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Webview" {
 			t.Errorf("Expected result.Name for '%s' to be 'Webview', but got '%s'", `Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36`, result.Os)
 		}
-		if result.OsVersion != "5.1.1" {
+		if true && result.OsVersion != "5.1.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '5.1.1', but got '%s'", `Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36`, result.OsVersion)
 		}
-		if result.Version != "4.0" {
+		if true && result.Version != "4.0" {
 			t.Errorf("Expected result.Version for '%s' to be '4.0', but got '%s'", `Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36`, result.Version)
 		}
 	}
@@ -238,13 +238,13 @@ func Test_smartphone_android_(t *testing.T) {
 		if result.Name != "Chrome" {
 			t.Errorf("Expected result.Name for '%s' to be 'Chrome', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.Name)
 		}
-		if result.Os != "Android" {
+		if true && result.Os != "Android" {
 			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.Os)
 		}
-		if result.OsVersion != "9" {
+		if true && result.OsVersion != "9" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '9', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.OsVersion)
 		}
-		if result.Version != "72.0.3626.105" {
+		if true && result.Version != "72.0.3626.105" {
 			t.Errorf("Expected result.Version for '%s' to be '72.0.3626.105', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.Version)
 		}
 	}

--- a/smartphone_android__test.go
+++ b/smartphone_android__test.go
@@ -148,6 +148,26 @@ func Test_smartphone_android_(t *testing.T) {
 			t.Errorf("Expected result.Version for '%s' to be '14.0', but got '%s'", `Mozilla/5.0 (Android; Tablet; rv:14.0) Gecko/14.0 Firefox/14.0`, result.Version)
 		}
 	}
+	result, err = Parse(`Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`)
+	if err != nil {
+		t.Errorf(`Failed to parse 'Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1': %s`, err)
+	} else {
+		if result.Category != "smartphone" {
+			t.Errorf("Expected result.Category for '%s' to be 'smartphone', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.Category)
+		}
+		if result.Name != "Edge" {
+			t.Errorf("Expected result.Name for '%s' to be 'Edge', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.Name)
+		}
+		if result.Os != "Android" {
+			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.Os)
+		}
+		if result.OsVersion != "8.0" {
+			t.Errorf("Expected result.OsVersion for '%s' to be '8.0', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.OsVersion)
+		}
+		if result.Version != "41.1.35.1" {
+			t.Errorf("Expected result.Version for '%s' to be '41.1.35.1', but got '%s'", `Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1`, result.Version)
+		}
+	}
 	result, err = Parse(`Dalvik/1.4.0 (Linux; U; Android 2.3.4; SBM009SH Build/S0008)`)
 	if err != nil {
 		t.Errorf(`Failed to parse 'Dalvik/1.4.0 (Linux; U; Android 2.3.4; SBM009SH Build/S0008)': %s`, err)
@@ -206,6 +226,26 @@ func Test_smartphone_android_(t *testing.T) {
 		}
 		if result.Version != "4.0" {
 			t.Errorf("Expected result.Version for '%s' to be '4.0', but got '%s'", `Mozilla/5.0 (Linux; Android 5.1.1; Nexus 5 Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/537.36`, result.Version)
+		}
+	}
+	result, err = Parse(`Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`)
+	if err != nil {
+		t.Errorf(`Failed to parse 'Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36': %s`, err)
+	} else {
+		if result.Category != "smartphone" {
+			t.Errorf("Expected result.Category for '%s' to be 'smartphone', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.Category)
+		}
+		if result.Name != "Chrome" {
+			t.Errorf("Expected result.Name for '%s' to be 'Chrome', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.Name)
+		}
+		if result.Os != "Android" {
+			t.Errorf("Expected result.Os for '%s' to be 'Android', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.Os)
+		}
+		if result.OsVersion != "9" {
+			t.Errorf("Expected result.OsVersion for '%s' to be '9', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.OsVersion)
+		}
+		if result.Version != "72.0.3626.105" {
+			t.Errorf("Expected result.Version for '%s' to be '72.0.3626.105', but got '%s'", `Mozilla/5.0 (Linux; Android 9; SM-N960F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36`, result.Version)
 		}
 	}
 

--- a/smartphone_ios_test.go
+++ b/smartphone_ios_test.go
@@ -18,13 +18,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3`, result.Name)
 		}
-		if result.Os != "iPhone" {
+		if true && result.Os != "iPhone" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPhone', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3`, result.Os)
 		}
-		if result.OsVersion != "5.0.1" {
+		if true && result.OsVersion != "5.0.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '5.0.1', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3`, result.OsVersion)
 		}
-		if result.Version != "5.1" {
+		if true && result.Version != "5.1" {
 			t.Errorf("Expected result.Version for '%s' to be '5.1', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4`, result.Name)
 		}
-		if result.Os != "iPhone" {
+		if true && result.Os != "iPhone" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPhone', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4`, result.Os)
 		}
-		if result.OsVersion != "8.1" {
+		if true && result.OsVersion != "8.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '8.1', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4`, result.OsVersion)
 		}
-		if result.Version != "8.0" {
+		if true && result.Version != "8.0" {
 			t.Errorf("Expected result.Version for '%s' to be '8.0', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12B411 Safari/600.1.4`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Webview" {
 			t.Errorf("Expected result.Name for '%s' to be 'Webview', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B411`, result.Name)
 		}
-		if result.Os != "iPhone" {
+		if true && result.Os != "iPhone" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPhone', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B411`, result.Os)
 		}
-		if result.OsVersion != "8.1" {
+		if true && result.OsVersion != "8.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '8.1', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B411`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if true && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B411`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5`, result.Name)
 		}
-		if result.Os != "iPad" {
+		if true && result.Os != "iPad" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPad', but got '%s'", `Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5`, result.Os)
 		}
-		if result.OsVersion != "4.3.2" {
+		if true && result.OsVersion != "4.3.2" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '4.3.2', but got '%s'", `Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5`, result.OsVersion)
 		}
-		if result.Version != "5.0.2" {
+		if true && result.Version != "5.0.2" {
 			t.Errorf("Expected result.Version for '%s' to be '5.0.2', but got '%s'", `Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8H7 Safari/6533.18.5`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Webview" {
 			t.Errorf("Expected result.Name for '%s' to be 'Webview', but got '%s'", `Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8L1`, result.Name)
 		}
-		if result.Os != "iPad" {
+		if true && result.Os != "iPad" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPad', but got '%s'", `Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8L1`, result.Os)
 		}
-		if result.OsVersion != "4.3.5" {
+		if true && result.OsVersion != "4.3.5" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '4.3.5', but got '%s'", `Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8L1`, result.OsVersion)
 		}
-		if result.Version != "5.0.2" {
+		if true && result.Version != "5.0.2" {
 			t.Errorf("Expected result.Version for '%s' to be '5.0.2', but got '%s'", `Mozilla/5.0 (iPad; U; CPU OS 4_3_5 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8L1`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (iPod; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3`, result.Name)
 		}
-		if result.Os != "iPod" {
+		if true && result.Os != "iPod" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPod', but got '%s'", `Mozilla/5.0 (iPod; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3`, result.Os)
 		}
-		if result.OsVersion != "5.0.1" {
+		if true && result.OsVersion != "5.0.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '5.0.1', but got '%s'", `Mozilla/5.0 (iPod; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3`, result.OsVersion)
 		}
-		if result.Version != "5.1" {
+		if true && result.Version != "5.1" {
 			t.Errorf("Expected result.Version for '%s' to be '5.1', but got '%s'", `Mozilla/5.0 (iPod; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53`, result.Name)
 		}
-		if result.Os != "iPod" {
+		if true && result.Os != "iPod" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPod', but got '%s'", `Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53`, result.Os)
 		}
-		if result.OsVersion != "7.0" {
+		if true && result.OsVersion != "7.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '7.0', but got '%s'", `Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53`, result.OsVersion)
 		}
-		if result.Version != "7.0" {
+		if true && result.Version != "7.0" {
 			t.Errorf("Expected result.Version for '%s' to be '7.0', but got '%s'", `Mozilla/5.0 (iPod touch; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Webview" {
 			t.Errorf("Expected result.Name for '%s' to be 'Webview', but got '%s'", `Mozilla/5.0 (iPod touch; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466`, result.Name)
 		}
-		if result.Os != "iPod" {
+		if true && result.Os != "iPod" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPod', but got '%s'", `Mozilla/5.0 (iPod touch; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466`, result.Os)
 		}
-		if result.OsVersion != "8.1.3" {
+		if true && result.OsVersion != "8.1.3" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '8.1.3', but got '%s'", `Mozilla/5.0 (iPod touch; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if true && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (iPod touch; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12B466`, result.Version)
 		}
 	}
@@ -178,13 +178,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Chrome" {
 			t.Errorf("Expected result.Name for '%s' to be 'Chrome', but got '%s'", `Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; ja-jp) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3`, result.Name)
 		}
-		if result.Os != "iPhone" {
+		if true && result.Os != "iPhone" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPhone', but got '%s'", `Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; ja-jp) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3`, result.Os)
 		}
-		if result.OsVersion != "5.1.1" {
+		if true && result.OsVersion != "5.1.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '5.1.1', but got '%s'", `Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; ja-jp) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3`, result.OsVersion)
 		}
-		if result.Version != "19.0.1084.60" {
+		if true && result.Version != "19.0.1084.60" {
 			t.Errorf("Expected result.Version for '%s' to be '19.0.1084.60', but got '%s'", `Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; ja-jp) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3`, result.Version)
 		}
 	}
@@ -198,13 +198,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4`, result.Name)
 		}
-		if result.Os != "iPhone" {
+		if true && result.Os != "iPhone" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPhone', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4`, result.Os)
 		}
-		if result.OsVersion != "8.3" {
+		if true && result.OsVersion != "8.3" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '8.3', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4`, result.OsVersion)
 		}
-		if result.Version != "1.0" {
+		if true && result.Version != "1.0" {
 			t.Errorf("Expected result.Version for '%s' to be '1.0', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4`, result.Version)
 		}
 	}
@@ -218,13 +218,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Edge" {
 			t.Errorf("Expected result.Name for '%s' to be 'Edge', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.Name)
 		}
-		if result.Os != "iPhone" {
+		if true && result.Os != "iPhone" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPhone', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.Os)
 		}
-		if result.OsVersion != "10.3.2" {
+		if true && result.OsVersion != "10.3.2" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.3.2', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.OsVersion)
 		}
-		if result.Version != "41.1.35.1" {
+		if true && result.Version != "41.1.35.1" {
 			t.Errorf("Expected result.Version for '%s' to be '41.1.35.1', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.Version)
 		}
 	}
@@ -238,13 +238,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Girls/2.0 (livedoor Co.,Ltd.; Peachy 2.1; iPhone; RSS Version 2.0; +http://girls.livedoor.com/)`, result.Name)
 		}
-		if result.Os != "iPhone" {
+		if true && result.Os != "iPhone" {
 			t.Errorf("Expected result.Os for '%s' to be 'iPhone', but got '%s'", `Girls/2.0 (livedoor Co.,Ltd.; Peachy 2.1; iPhone; RSS Version 2.0; +http://girls.livedoor.com/)`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Girls/2.0 (livedoor Co.,Ltd.; Peachy 2.1; iPhone; RSS Version 2.0; +http://girls.livedoor.com/)`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Girls/2.0 (livedoor Co.,Ltd.; Peachy 2.1; iPhone; RSS Version 2.0; +http://girls.livedoor.com/)`, result.Version)
 		}
 	}
@@ -258,13 +258,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `MobileSafari/7534.48.3 CFNetwork/548.0.4 Darwin/11.0.0`, result.Name)
 		}
-		if result.Os != "iOS" {
+		if true && result.Os != "iOS" {
 			t.Errorf("Expected result.Os for '%s' to be 'iOS', but got '%s'", `MobileSafari/7534.48.3 CFNetwork/548.0.4 Darwin/11.0.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `MobileSafari/7534.48.3 CFNetwork/548.0.4 Darwin/11.0.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if true && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `MobileSafari/7534.48.3 CFNetwork/548.0.4 Darwin/11.0.0`, result.Version)
 		}
 	}
@@ -278,13 +278,13 @@ func Test_smartphone_ios(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `Blogos/1.13 CFNetwork/548.0.4 Darwin/11.0.0`, result.Name)
 		}
-		if result.Os != "iOS" {
+		if true && result.Os != "iOS" {
 			t.Errorf("Expected result.Os for '%s' to be 'iOS', but got '%s'", `Blogos/1.13 CFNetwork/548.0.4 Darwin/11.0.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Blogos/1.13 CFNetwork/548.0.4 Darwin/11.0.0`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Blogos/1.13 CFNetwork/548.0.4 Darwin/11.0.0`, result.Version)
 		}
 	}

--- a/smartphone_ios_test.go
+++ b/smartphone_ios_test.go
@@ -208,6 +208,26 @@ func Test_smartphone_ios(t *testing.T) {
 			t.Errorf("Expected result.Version for '%s' to be '1.0', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4`, result.Version)
 		}
 	}
+	result, err = Parse(`Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`)
+	if err != nil {
+		t.Errorf(`Failed to parse 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1': %s`, err)
+	} else {
+		if result.Category != "smartphone" {
+			t.Errorf("Expected result.Category for '%s' to be 'smartphone', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.Category)
+		}
+		if result.Name != "Edge" {
+			t.Errorf("Expected result.Name for '%s' to be 'Edge', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.Name)
+		}
+		if result.Os != "iPhone" {
+			t.Errorf("Expected result.Os for '%s' to be 'iPhone', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.Os)
+		}
+		if result.OsVersion != "10.3.2" {
+			t.Errorf("Expected result.OsVersion for '%s' to be '10.3.2', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.OsVersion)
+		}
+		if result.Version != "41.1.35.1" {
+			t.Errorf("Expected result.Version for '%s' to be '41.1.35.1', but got '%s'", `Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1`, result.Version)
+		}
+	}
 	result, err = Parse(`Girls/2.0 (livedoor Co.,Ltd.; Peachy 2.1; iPhone; RSS Version 2.0; +http://girls.livedoor.com/)`)
 	if err != nil {
 		t.Errorf(`Failed to parse 'Girls/2.0 (livedoor Co.,Ltd.; Peachy 2.1; iPhone; RSS Version 2.0; +http://girls.livedoor.com/)': %s`, err)

--- a/smartphone_misc_test.go
+++ b/smartphone_misc_test.go
@@ -21,10 +21,9 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Os != "Firefox OS" {
 			t.Errorf("Expected result.Os for '%s' to be 'Firefox OS', but got '%s'", `Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0`, result.Os)
 		}
-		/* Skip for now
 		if result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0`, result.OsVersion)
-		}*/
+		}
 		if result.Version != "18.0" {
 			t.Errorf("Expected result.Version for '%s' to be '18.0', but got '%s'", `Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0`, result.Version)
 		}
@@ -102,10 +101,9 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Os != "Windows CE" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows CE', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.7) S12HT`, result.Os)
 		}
-		/* Skip for now
 		if result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.7) S12HT`, result.OsVersion)
-		}*/
+		}
 		if result.Version != "6.0" {
 			t.Errorf("Expected result.Version for '%s' to be '6.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.7) S12HT`, result.Version)
 		}

--- a/smartphone_misc_test.go
+++ b/smartphone_misc_test.go
@@ -18,13 +18,13 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0`, result.Name)
 		}
-		if result.Os != "Firefox OS" {
+		if true && result.Os != "Firefox OS" {
 			t.Errorf("Expected result.Os for '%s' to be 'Firefox OS', but got '%s'", `Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0`, result.OsVersion)
 		}
-		if result.Version != "18.0" {
+		if true && result.Version != "18.0" {
 			t.Errorf("Expected result.Version for '%s' to be '18.0', but got '%s'", `Mozilla/5.0 (Mobile; rv:18.0) Gecko/18.0 Firefox/18.0`, result.Version)
 		}
 	}
@@ -38,13 +38,13 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Name != "Firefox" {
 			t.Errorf("Expected result.Name for '%s' to be 'Firefox', but got '%s'", `Mozilla/5.0 (Tablet; rv:26.0) Gecko/18.0 Firefox/26.0`, result.Name)
 		}
-		if result.Os != "Firefox OS" {
+		if true && result.Os != "Firefox OS" {
 			t.Errorf("Expected result.Os for '%s' to be 'Firefox OS', but got '%s'", `Mozilla/5.0 (Tablet; rv:26.0) Gecko/18.0 Firefox/26.0`, result.Os)
 		}
-		if result.OsVersion != "26.0" {
+		if true && result.OsVersion != "26.0" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '26.0', but got '%s'", `Mozilla/5.0 (Tablet; rv:26.0) Gecko/18.0 Firefox/26.0`, result.OsVersion)
 		}
-		if result.Version != "26.0" {
+		if true && result.Version != "26.0" {
 			t.Errorf("Expected result.Version for '%s' to be '26.0', but got '%s'", `Mozilla/5.0 (Tablet; rv:26.0) Gecko/18.0 Firefox/26.0`, result.Version)
 		}
 	}
@@ -58,13 +58,13 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.5; Trident/3.1; IEMobile/7.0; FujitsuToshibaMobileCommun; IS12T; KDDI)`, result.Name)
 		}
-		if result.Os != "Windows Phone OS" {
+		if true && result.Os != "Windows Phone OS" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows Phone OS', but got '%s'", `Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.5; Trident/3.1; IEMobile/7.0; FujitsuToshibaMobileCommun; IS12T; KDDI)`, result.Os)
 		}
-		if result.OsVersion != "7.5" {
+		if true && result.OsVersion != "7.5" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '7.5', but got '%s'", `Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.5; Trident/3.1; IEMobile/7.0; FujitsuToshibaMobileCommun; IS12T; KDDI)`, result.OsVersion)
 		}
-		if result.Version != "7.0" {
+		if true && result.Version != "7.0" {
 			t.Errorf("Expected result.Version for '%s' to be '7.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.5; Trident/3.1; IEMobile/7.0; FujitsuToshibaMobileCommun; IS12T; KDDI)`, result.Version)
 		}
 	}
@@ -78,13 +78,13 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 930) like Gecko`, result.Name)
 		}
-		if result.Os != "Windows Phone OS" {
+		if true && result.Os != "Windows Phone OS" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows Phone OS', but got '%s'", `Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 930) like Gecko`, result.Os)
 		}
-		if result.OsVersion != "8.1" {
+		if true && result.OsVersion != "8.1" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '8.1', but got '%s'", `Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 930) like Gecko`, result.OsVersion)
 		}
-		if result.Version != "11.0" {
+		if true && result.Version != "11.0" {
 			t.Errorf("Expected result.Version for '%s' to be '11.0', but got '%s'", `Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 930) like Gecko`, result.Version)
 		}
 	}
@@ -98,13 +98,13 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Name != "Internet Explorer" {
 			t.Errorf("Expected result.Name for '%s' to be 'Internet Explorer', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.7) S12HT`, result.Name)
 		}
-		if result.Os != "Windows CE" {
+		if true && result.Os != "Windows CE" {
 			t.Errorf("Expected result.Os for '%s' to be 'Windows CE', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.7) S12HT`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.7) S12HT`, result.OsVersion)
 		}
-		if result.Version != "6.0" {
+		if true && result.Version != "6.0" {
 			t.Errorf("Expected result.Version for '%s' to be '6.0', but got '%s'", `Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.7) S12HT`, result.Version)
 		}
 	}
@@ -118,13 +118,13 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Name != "Opera" {
 			t.Errorf("Expected result.Name for '%s' to be 'Opera', but got '%s'", `Opera/9.80 (BlackBerry; Opera Mini/6.5.27548/26.1305; U; ja) Presto/2.8.119 Version/10.54`, result.Name)
 		}
-		if result.Os != "BlackBerry" {
+		if true && result.Os != "BlackBerry" {
 			t.Errorf("Expected result.Os for '%s' to be 'BlackBerry', but got '%s'", `Opera/9.80 (BlackBerry; Opera Mini/6.5.27548/26.1305; U; ja) Presto/2.8.119 Version/10.54`, result.Os)
 		}
-		if result.OsVersion != "UNKNOWN" {
+		if false && result.OsVersion != "UNKNOWN" {
 			t.Errorf("Expected result.OsVersion for '%s' to be 'UNKNOWN', but got '%s'", `Opera/9.80 (BlackBerry; Opera Mini/6.5.27548/26.1305; U; ja) Presto/2.8.119 Version/10.54`, result.OsVersion)
 		}
-		if result.Version != "10.54" {
+		if true && result.Version != "10.54" {
 			t.Errorf("Expected result.Version for '%s' to be '10.54', but got '%s'", `Opera/9.80 (BlackBerry; Opera Mini/6.5.27548/26.1305; U; ja) Presto/2.8.119 Version/10.54`, result.Version)
 		}
 	}
@@ -138,13 +138,13 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Name != "UNKNOWN" {
 			t.Errorf("Expected result.Name for '%s' to be 'UNKNOWN', but got '%s'", `BlackBerry9700/5.0.0.1014 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/220`, result.Name)
 		}
-		if result.Os != "BlackBerry" {
+		if true && result.Os != "BlackBerry" {
 			t.Errorf("Expected result.Os for '%s' to be 'BlackBerry', but got '%s'", `BlackBerry9700/5.0.0.1014 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/220`, result.Os)
 		}
-		if result.OsVersion != "5.0.0.1014" {
+		if true && result.OsVersion != "5.0.0.1014" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '5.0.0.1014', but got '%s'", `BlackBerry9700/5.0.0.1014 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/220`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `BlackBerry9700/5.0.0.1014 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/220`, result.Version)
 		}
 	}
@@ -158,13 +158,13 @@ func Test_smartphone_misc(t *testing.T) {
 		if result.Name != "Safari" {
 			t.Errorf("Expected result.Name for '%s' to be 'Safari', but got '%s'", `Mozilla/5.0 (BB10; Touch) AppleWebKit/537.35+ (KHTML, like Gecko) Version/10.3.1.2243 Mobile Safari/537.35+`, result.Name)
 		}
-		if result.Os != "BlackBerry 10" {
+		if true && result.Os != "BlackBerry 10" {
 			t.Errorf("Expected result.Os for '%s' to be 'BlackBerry 10', but got '%s'", `Mozilla/5.0 (BB10; Touch) AppleWebKit/537.35+ (KHTML, like Gecko) Version/10.3.1.2243 Mobile Safari/537.35+`, result.Os)
 		}
-		if result.OsVersion != "10.3.1.2243" {
+		if true && result.OsVersion != "10.3.1.2243" {
 			t.Errorf("Expected result.OsVersion for '%s' to be '10.3.1.2243', but got '%s'", `Mozilla/5.0 (BB10; Touch) AppleWebKit/537.35+ (KHTML, like Gecko) Version/10.3.1.2243 Mobile Safari/537.35+`, result.OsVersion)
 		}
-		if result.Version != "UNKNOWN" {
+		if false && result.Version != "UNKNOWN" {
 			t.Errorf("Expected result.Version for '%s' to be 'UNKNOWN', but got '%s'", `Mozilla/5.0 (BB10; Touch) AppleWebKit/537.35+ (KHTML, like Gecko) Version/10.3.1.2243 Mobile Safari/537.35+`, result.Version)
 		}
 	}


### PR DESCRIPTION
And v1.9 spec too.
This change also introduced the change to ignore undefined Testset attribute (In past, test code generator generated to check equality to `"UNKNOWN"` and some tests were failing).